### PR TITLE
backend-api-prefix-migration: Migrate API routes to /api/ prefix with backward-compatible redirects

### DIFF
--- a/server/server.php
+++ b/server/server.php
@@ -49,8 +49,11 @@ Amp\Loop::run(function () {
     /**  Server back-end API                                  **/
     /***********************************************************/
 
-    $router->addRoute('POST', '/create', ServerRoutes::createSecret($logger, $redisClient));
-    $router->addRoute('POST', '/retrieve', ServerRoutes::retrieveSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/create', ServerRoutes::createSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecret($logger, $redisClient));
+
+    $router->addRoute('POST', '/create', ServerRoutes::redirect('/api/create'));
+    $router->addRoute('POST', '/retrieve', ServerRoutes::redirect('/api/retrieve'));
 
     $router->setFallback($documentRoot);
 

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -55,6 +55,19 @@ class ServerRoutes
     }
 
     /**
+     * Create a callback that issues a 307 Temporary Redirect to the given location.
+     *
+     * @param string $location
+     * @return CallableRequestHandler
+     */
+    public static function redirect(string $location): CallableRequestHandler
+    {
+        return new CallableRequestHandler(function() use ($location): Response {
+            return new Response(Status::TEMPORARY_REDIRECT, ['location' => $location], '');
+        });
+    }
+
+    /**
      * Process a secret creation request and attempt to create the secret.
      *
      * @param Logger $logger


### PR DESCRIPTION
## Summary

Implements ticket **backend-api-prefix-migration**.

### Changes

- **`POST /api/create`** and **`POST /api/retrieve`** are now the canonical API endpoints, handling all secret creation and retrieval logic.
- **`POST /create`** and **`POST /retrieve`** now return **307 Temporary Redirect** responses to their `/api/` counterparts, preserving the request method so existing clients continue to work without modification.
- Added `ServerRoutes::redirect(string $location)` helper method that returns a `CallableRequestHandler` issuing a 307 redirect.

### Acceptance Criteria

- [x] `POST /api/create` handles secret creation requests
- [x] `POST /api/retrieve` handles secret retrieval requests
- [x] `POST /create` returns a 307 redirect to `/api/create`
- [x] `POST /retrieve` returns a 307 redirect to `/api/retrieve`
- [x] Existing v1 text/plain format continues to work on the new routes