### PR TITLE
backend-api-prefix-migration: Migrate API routes to /api/ prefix with backward-compatible redirects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Swordfish — Agent Memory
+
+## Repository Overview
+Secret-sharing web application with a PHP/Amp HTTP server backend and a PHP Symfony Console CLI client.
+
+## Structure
+- `server/` — Amp HTTP Server (PHP). Entry point: `server.php`. Source classes in `src/`.
+- `cli/` — Symfony Console CLI. Entry point: `cli.php`. Source classes in `src/`.
+- `swagger.yml` — OpenAPI spec (canonical API definition).
+- `helm/` — Kubernetes Helm chart for deployment.
+- `Makefile` — Docker-based build/run targets (`server-build`, `server-up`, `server-down`, `server-install`, `cli-install`).
+
+## Key Source Files
+| File | Purpose |
+|------|---------|
+| `server/server.php` | Registers all HTTP routes via `Amp\Http\Server\Router` |
+| `server/src/ServerRoutes.php` | Static factory methods returning `CallableRequestHandler` instances |
+| `server/src/CreateRequest.php` | Deserializes and validates secret-creation payloads |
+| `server/src/RetrievalRequest.php` | Deserializes and validates secret-retrieval payloads |
+| `cli/src/CreateSecretCommand.php` | `secret:create` CLI command; POSTs to `/api/create` |
+| `cli/src/RetrieveSecretCommand.php` | `secret:retrieve` CLI command; POSTs to `/api/retrieve` |
+
+## API Routes (current)
+| Method | Path | Handler |
+|--------|------|---------|
+| GET | `/` | `ServerRoutes::mainContent()` |
+| GET | `/secret` | `ServerRoutes::secretRetrieval()` |
+| GET | `/secret/{secretId}` | `ServerRoutes::secretRetrieval()` |
+| POST | `/api/create` | `ServerRoutes::createSecret()` — canonical |
+| POST | `/api/retrieve` | `ServerRoutes::retrieveSecret()` — canonical |
+| POST | `/create` | `ServerRoutes::redirect('/api/create')` — 307 compat |
+| POST | `/retrieve` | `ServerRoutes::redirect('/api/retrieve')` — 307 compat |
+
+## Linting / Testing
+- No phpcs/phpstan/phpunit config present. Use `php -l <file>` for syntax checking.
+- No automated test suite; verify logic manually or via integration tests against a running server.
+
+## Dependencies
+- Server: `amphp/http-server`, `amphp/http-server-router`, `amphp/http-server-static-content`, `predis/predis`, `amphp/log`
+- CLI: `symfony/console`, `ext-sodium`, `ext-curl`
+- Install via Docker: `make server-install` / `make cli-install`
+
+## Git / PR Workflow
+- Feature branches pushed to `origin` (GitHub: `DisplaceTech/swordfish`).
+- PRs opened against `main`. Title must start with the ticket ID.
+- Use GitHub REST API (`/repos/DisplaceTech/swordfish/pulls`) if `gh pr create` stalls.
+- Existing git credentials: Eric Mann <eric@eamann.com>; add `Co-authored-by: openhands <openhands@all-hands.dev>` to commits.

--- a/cli/src/CreateSecretCommand.php
+++ b/cli/src/CreateSecretCommand.php
@@ -37,12 +37,13 @@ class CreateSecretCommand extends Command
         $payload = bin2hex($salt) . '$' . $verifier . '$' . $encrypted;
 
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, "{$serverUrl}/create");
+        curl_setopt($ch, CURLOPT_URL, "{$serverUrl}/api/create");
         curl_setopt($ch, CURLOPT_USERAGENT, 'Swordfish CLI');
         curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: text/plain']);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
 
         $response = curl_exec($ch);
 

--- a/cli/src/RetrieveSecretCommand.php
+++ b/cli/src/RetrieveSecretCommand.php
@@ -30,12 +30,13 @@ class RetrieveSecretCommand extends Command
         $payload = $secretId . '$' . $verifier;
 
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, "{$serverUrl}/retrieve");
+        curl_setopt($ch, CURLOPT_URL, "{$serverUrl}/api/retrieve");
         curl_setopt($ch, CURLOPT_USERAGENT, 'Swordfish CLI');
         curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: text/plain']);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
 
         $response = curl_exec($ch);
 

--- a/server/server.php
+++ b/server/server.php
@@ -49,8 +49,11 @@ Amp\Loop::run(function () {
     /**  Server back-end API                                  **/
     /***********************************************************/
 
-    $router->addRoute('POST', '/create', ServerRoutes::createSecret($logger, $redisClient));
-    $router->addRoute('POST', '/retrieve', ServerRoutes::retrieveSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/create', ServerRoutes::createSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecret($logger, $redisClient));
+
+    $router->addRoute('POST', '/create', ServerRoutes::redirect('/api/create'));
+    $router->addRoute('POST', '/retrieve', ServerRoutes::redirect('/api/retrieve'));
 
     $router->setFallback($documentRoot);
 

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -55,6 +55,19 @@ class ServerRoutes
     }
 
     /**
+     * Create a callback that issues a 307 Temporary Redirect to the given location.
+     *
+     * @param string $location
+     * @return CallableRequestHandler
+     */
+    public static function redirect(string $location): CallableRequestHandler
+    {
+        return new CallableRequestHandler(function() use ($location): Response {
+            return new Response(Status::TEMPORARY_REDIRECT, ['location' => $location], '');
+        });
+    }
+
+    /**
      * Process a secret creation request and attempt to create the secret.
      *
      * @param Logger $logger


### PR DESCRIPTION
## Summary

Closes ticket: **backend-api-prefix-migration**

Migrates the backend API routes to use the `/api/` prefix as the canonical path, while preserving full backward compatibility via HTTP 307 redirects.

## Changes

### Server (`server/`)
- **`server.php`**: Registers `POST /api/create` and `POST /api/retrieve` as the new canonical routes. Registers `POST /create` and `POST /retrieve` as 307 redirect routes pointing to their `/api/` counterparts.
- **`src/ServerRoutes.php`**: Adds a `redirect(string $location): CallableRequestHandler` static helper that returns a `307 Temporary Redirect` response with the given `Location` header.

### CLI (`cli/`)
- **`src/CreateSecretCommand.php`**: Updates the target URL to `/api/create` and enables `CURLOPT_FOLLOWLOCATION` so the client transparently follows any 307 redirects.
- **`src/RetrieveSecretCommand.php`**: Updates the target URL to `/api/retrieve` and enables `CURLOPT_FOLLOWLOCATION` for the same reason.

## Acceptance Criteria

- [x] `POST /api/create` works as the canonical create route
- [x] `POST /api/retrieve` works as the canonical retrieve route
- [x] `POST /create` issues a 307 redirect to `POST /api/create`
- [x] `POST /retrieve` issues a 307 redirect to `POST /api/retrieve`
- [x] Existing CLI continues to work (now targets `/api/` directly; `CURLOPT_FOLLOWLOCATION` ensures redirect compatibility for any other clients)
- [x] All PHP files pass `php -l` linting