### PR TITLE
health-endpoint: Add GET /health endpoint with Redis check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Swordfish — Agent Memory
+
+## Repository Overview
+PHP secret-sharing application using the Amphp async HTTP server framework. Secrets are stored in Redis via Predis.
+
+## Structure
+- `server/` — Main PHP HTTP server (Amphp v2, PHP 8.4)
+  - `server.php` — Entry point: wires up sockets, Redis client, and routes
+  - `src/ServerRoutes.php` — All route handlers as static factory methods returning `CallableRequestHandler`
+  - `src/CreateRequest.php` / `src/RetrievalRequest.php` — Request value objects
+  - `docker-compose.yml` — Production compose (server + redis)
+  - `docker-compose.dev.yml` — Dev overrides
+  - `Dockerfile` — Multi-stage: composer builder → php:8.4-cli runtime
+- `cli/` — PHP CLI tool for interacting with the server
+- `helm/` — Helm chart for Kubernetes deployment
+- `swagger.yml` — OpenAPI 2.0 spec (update when adding routes)
+
+## Key Patterns
+- **Route registration**: Add `$router->addRoute(METHOD, PATH, ServerRoutes::handlerName(...))` in `server.php`
+- **Handler factory**: Add a `public static function handlerName(Logger, Client): CallableRequestHandler` to `ServerRoutes.php`
+- **Async**: Amphp coroutines — use `yield` for async I/O inside handlers; Predis calls are synchronous
+- **Redis errors**: Catch `\Exception` around Predis calls; `ConnectionException` is thrown when Redis is unreachable
+- **HTTP status codes**: Use `Amp\Http\Status` constants (e.g., `Status::OK`, `Status::SERVICE_UNAVAILABLE`)
+- **JSON responses**: Set `content-type: application/json` header and use `json_encode()`
+
+## Build & Run
+```bash
+make server-up        # build image and start containers (requires Docker)
+make server-down      # stop containers
+make server-install   # install Composer deps locally via Docker
+```
+
+## Environment Variables
+| Variable | Default | Description |
+|---|---|---|
+| `REDIS_HOST` | redis | Redis hostname |
+| `REDIS_PORT` | 6379 | Redis port |
+| `SERVER_PORT` | 8080 | HTTP listen port |
+
+## CI/CD
+- GitHub Actions workflow at `.github/workflows/build.yml` builds and pushes the Docker image to GHCR on pushes to `main` or PRs touching `server/**`
+- Git remotes: `origin` → GitHub (`DisplaceTech/swordfish`), `fj` → internal Forgejo instance
+
+## No Formal Test Suite
+The project has no phpunit or phpcs configuration. Linting/testing is done by building and running the Docker image.

--- a/server/server.php
+++ b/server/server.php
@@ -44,6 +44,7 @@ Amp\Loop::run(function () {
     $router->addRoute('GET', '/', ServerRoutes::mainContent($logger));
     $router->addRoute('GET', '/secret', ServerRoutes::secretRetrieval($logger));
     $router->addRoute('GET', '/secret/{secretId}', ServerRoutes::secretRetrieval($logger));
+    $router->addRoute('GET', '/health', ServerRoutes::healthCheck($logger, $redisClient));
 
     /***********************************************************/
     /**  Server back-end API                                  **/

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -91,6 +91,35 @@ class ServerRoutes
     }
 
     /**
+     * Check Redis connectivity and return service health status.
+     *
+     * @param Logger $logger
+     * @param Client $redisClient
+     * @return CallableRequestHandler
+     */
+    public static function healthCheck(Logger $logger, Client $redisClient): CallableRequestHandler
+    {
+        return new CallableRequestHandler(function() use ($logger, $redisClient): Response {
+            try {
+                $redisClient->ping();
+                $logger->info('Health check: Redis reachable');
+                return new Response(
+                    Status::OK,
+                    ['content-type' => 'application/json'],
+                    json_encode(['status' => 'ok'])
+                );
+            } catch (\Exception $e) {
+                $logger->error('Health check: Redis unreachable - ' . $e->getMessage());
+                return new Response(
+                    Status::SERVICE_UNAVAILABLE,
+                    ['content-type' => 'application/json'],
+                    json_encode(['status' => 'error', 'detail' => 'redis unreachable'])
+                );
+            }
+        });
+    }
+
+    /**
      * Handle API requests to retrieve a secret.
      *
      * @param Logger $logger

--- a/swagger.yml
+++ b/swagger.yml
@@ -55,6 +55,34 @@ paths:
         "200":
           description: "OK"
 
+  /health:
+    get:
+      summary: "Check service health including Redis connectivity."
+      tags:
+        - "api"
+      produces:
+        - "application/json"
+      responses:
+        "200":
+          description: "Service is healthy"
+          schema:
+            type: "object"
+            properties:
+              status:
+                type: "string"
+                example: "ok"
+        "503":
+          description: "Service unavailable — Redis unreachable"
+          schema:
+            type: "object"
+            properties:
+              status:
+                type: "string"
+                example: "error"
+              detail:
+                type: "string"
+                example: "redis unreachable"
+
   /api/create:
     post:
       summary: "Create a new secret in the datastore."


### PR DESCRIPTION
## Summary

Closes ticket: **health-endpoint**

Adds a `GET /health` route that checks Redis connectivity and returns a JSON response indicating service health.

## Behaviour

| Redis state | HTTP status | Response body |
|---|---|---|
| Reachable | 200 OK | `{"status":"ok"}` |
| Unreachable | 503 Service Unavailable | `{"status":"error","detail":"redis unreachable"}` |

## Changes

- `server/src/ServerRoutes.php` — Added `healthCheck()` handler that calls `$redisClient->ping()` and returns the appropriate JSON response
- `server/server.php` — Registered `GET /health` route
- `swagger.yml` — Documented the new endpoint with 200 and 503 response schemas

## Notes

This endpoint is intended for use as a Kubernetes liveness/readiness probe.