### PR TITLE
DIS-649: Add GET /health endpoint with Redis connectivity check

### DIFF
--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -113,7 +113,7 @@ class ServerRoutes
                 return new Response(
                     Status::SERVICE_UNAVAILABLE,
                     ['content-type' => 'application/json'],
-                    json_encode(['status' => 'error', 'detail' => 'redis unreachable'])
+                    json_encode(['status' => 'error', 'message' => $e->getMessage()])
                 );
             }
         });

--- a/swagger.yml
+++ b/swagger.yml
@@ -79,9 +79,9 @@ paths:
               status:
                 type: "string"
                 example: "error"
-              detail:
+              message:
                 type: "string"
-                example: "redis unreachable"
+                example: "Connection refused [tcp://redis:6379]"
 
   /api/create:
     post:


### PR DESCRIPTION
## Summary

Implements the `GET /health` endpoint that checks Redis connectivity and returns an appropriate JSON response.

Closes / references: [DIS-649](https://linear.app/displace-tech/issue/DIS-649/add-get-health-endpoint-with-redis-connectivity-check)

## Changes

- **`server/src/ServerRoutes.php`** — Added `healthCheck()` handler: pings Redis and returns `200 {"status": "ok"}` on success, or `503 {"status": "error", "message": "..."}` (with the actual exception message) when Redis is unreachable.
- **`server/server.php`** — Registered `GET /health` route.
- **`swagger.yml`** — Documented the `/health` endpoint with `200` and `503` response schemas.

## Acceptance Criteria

- [x] `GET /health` returns `{"status": "ok"}` with HTTP 200 when Redis is reachable.
- [x] `GET /health` returns `{"status": "error", "message": "..."}` with HTTP 503 when Redis is down.