### PR TITLE
DIS-653: Add Keel annotations to Helm chart for automated deployment

### DIFF
--- a/helm/swordfish/templates/deployment.yaml
+++ b/helm/swordfish/templates/deployment.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     {{- include "swordfish.labels" . | nindent 4 }}
   annotations:
-    keel.sh/policy: "force"
-    keel.sh/trigger: "poll"
-    keel.sh/pollSchedule: "@every 5m"
-    keel.sh/match-tag: "true"
+    keel.sh/policy: {{ .Values.keel.policy | quote }}
+    keel.sh/trigger: {{ .Values.keel.trigger | quote }}
+    keel.sh/pollSchedule: {{ .Values.keel.pollSchedule | quote }}
+    keel.sh/match-tag: {{ .Values.keel.matchTag | quote }}
 spec:
   replicas: {{ .Values.server.replicaCount }}
   selector:

--- a/helm/swordfish/values.yaml
+++ b/helm/swordfish/values.yaml
@@ -49,6 +49,16 @@ redis:
         cpu: 200m
         memory: 256Mi
 
+keel:
+  # -- Keel update policy: "force" for latest tag, "semver" for tagged releases, "glob" for pattern matching
+  policy: "force"
+  # -- Keel trigger type: "poll" to periodically check for new images, "pubsub" for event-driven updates
+  trigger: "poll"
+  # -- Poll schedule (cron or @every syntax); only used when trigger is "poll"
+  pollSchedule: "@every 5m"
+  # -- Only update when the image tag matches the currently deployed tag
+  matchTag: "true"
+
 ingress:
   enabled: false
   className: ""


### PR DESCRIPTION
## Summary

Adds Keel annotations to the Helm chart Deployment template to enable automated image updates when new images are pushed to GHCR.

The annotations were previously hardcoded in the template (commit `560e399`). This PR moves them into `values.yaml` under a dedicated `keel` section so operators can configure the policy, trigger, poll schedule, and match-tag per deployment without editing the template directly.

## Changes

- **`helm/swordfish/values.yaml`** — new `keel` section with configurable defaults:
  - `keel.policy: "force"` — update on every new image push (use `"semver"` for tagged releases)
  - `keel.trigger: "poll"` — periodically check GHCR for new images
  - `keel.pollSchedule: "@every 5m"` — poll interval
  - `keel.matchTag: "true"` — only update when the tag matches the deployed tag
- **`helm/swordfish/templates/deployment.yaml`** — annotation values now reference `{{ .Values.keel.* }}` instead of hardcoded strings

## Acceptance Criteria

- [x] `keel.sh/policy` annotation present on the Deployment
- [x] `keel.sh/trigger` annotation present on the Deployment
- [x] Keel will detect new image pushes to GHCR and update the deployment automatically
- [x] Policy is configurable via `values.yaml` (supports `force`, `semver`, `glob`, etc.)

## Testing

```bash
# Lint passes
helm lint helm/swordfish

# Default values render correctly
helm template swordfish helm/swordfish | grep "keel.sh"
# keel.sh/policy: "force"
# keel.sh/trigger: "poll"
# keel.sh/pollSchedule: "@every 5m"
# keel.sh/match-tag: "true"

# Override to semver for tagged releases
helm template swordfish helm/swordfish --set keel.policy=semver | grep "keel.sh/policy"
# keel.sh/policy: "semver"
```

Resolves: [DIS-653](https://linear.app/displace-tech/issue/DIS-653/add-keel-annotations-to-helm-chart-for-automated-deployment)