### PR TITLE
DIS-650: Implement POST /api/create with JSON request/response

### DIFF
--- a/server/server.php
+++ b/server/server.php
@@ -52,6 +52,7 @@ Amp\Loop::run(function () {
 
     $router->addRoute('POST', '/create', ServerRoutes::createSecret($logger, $redisClient));
     $router->addRoute('POST', '/retrieve', ServerRoutes::retrieveSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/create', ServerRoutes::apiCreateSecret($logger, $redisClient));
 
     $router->setFallback($documentRoot);
 

--- a/server/src/JsonCreateRequest.php
+++ b/server/src/JsonCreateRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Swordfish\Server;
+
+class JsonCreateRequest
+{
+    public const MAX_TTL = 604800;
+
+    protected string $encryptedSecret;
+    protected int $ttl;
+    protected int $maxViews;
+
+    public function __construct(string $encryptedSecret, int $ttl, int $maxViews)
+    {
+        $this->encryptedSecret = $encryptedSecret;
+        $this->ttl = $ttl;
+        $this->maxViews = $maxViews;
+    }
+
+    public function encryptedSecret(): string
+    {
+        return $this->encryptedSecret;
+    }
+
+    public function ttl(): int
+    {
+        return $this->ttl;
+    }
+
+    public function maxViews(): int
+    {
+        return $this->maxViews;
+    }
+
+    /**
+     * Parse and validate a JSON request body.
+     *
+     * @param string $raw
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return JsonCreateRequest
+     */
+    public static function fromString(string $raw): JsonCreateRequest
+    {
+        $data = json_decode($raw, true);
+        if (!is_array($data)) {
+            throw new \InvalidArgumentException('Invalid JSON body');
+        }
+
+        if (empty($data['encrypted_secret']) || !is_string($data['encrypted_secret'])) {
+            throw new \InvalidArgumentException('Missing or invalid encrypted_secret');
+        }
+
+        if (!isset($data['ttl']) || !is_int($data['ttl'])) {
+            throw new \InvalidArgumentException('Missing or invalid ttl');
+        }
+
+        if ($data['ttl'] < 1 || $data['ttl'] > self::MAX_TTL) {
+            throw new \InvalidArgumentException(sprintf('ttl must be between 1 and %d', self::MAX_TTL));
+        }
+
+        if (!isset($data['max_views']) || !is_int($data['max_views'])) {
+            throw new \InvalidArgumentException('Missing or invalid max_views');
+        }
+
+        if ($data['max_views'] < 1) {
+            throw new \InvalidArgumentException('max_views must be at least 1');
+        }
+
+        return new self($data['encrypted_secret'], $data['ttl'], $data['max_views']);
+    }
+}

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -91,6 +91,69 @@ class ServerRoutes
     }
 
     /**
+     * Handle JSON API requests to create a new secret.
+     *
+     * @param Logger $logger
+     * @param Client $redisClient
+     * @return CallableRequestHandler
+     */
+    public static function apiCreateSecret(Logger $logger, Client $redisClient): CallableRequestHandler
+    {
+        return new CallableRequestHandler(function(Request $request) use ($logger, $redisClient) {
+            $data = yield $request->getBody()->read();
+            if (strlen($data) > 100 * 1000) {
+                $logger->error('Message payload too large!');
+                return new Response(
+                    Status::PAYLOAD_TOO_LARGE,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Payload Too Large'])
+                );
+            }
+
+            try {
+                $createRequest = JsonCreateRequest::fromString($data);
+            } catch (\InvalidArgumentException $e) {
+                $logger->error('Invalid JSON create request: ' . $e->getMessage());
+                return new Response(
+                    Status::BAD_REQUEST,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => $e->getMessage()])
+                );
+            }
+
+            $secretID = bin2hex(random_bytes(6));
+            $secretKey = "secret:{$secretID}";
+            $viewsKey = "views:{$secretID}";
+            $ttl = $createRequest->ttl();
+
+            try {
+                $redisClient->setex($secretKey, $ttl, $createRequest->encryptedSecret());
+                $redisClient->setex($viewsKey, $ttl, $createRequest->maxViews());
+            } catch (\Exception $e) {
+                $logger->error('Redis error during secret creation: ' . $e->getMessage());
+                return new Response(
+                    Status::SERVICE_UNAVAILABLE,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Service unavailable'])
+                );
+            }
+
+            $expiresAt = time() + $ttl;
+            $logger->info(sprintf('Created JSON API secret %s (ttl=%d, max_views=%d)', $secretID, $ttl, $createRequest->maxViews()));
+
+            return new Response(
+                Status::CREATED,
+                ['content-type' => 'application/json'],
+                json_encode([
+                    'id'         => $secretID,
+                    'expires_at' => $expiresAt,
+                    'max_views'  => $createRequest->maxViews(),
+                ])
+            );
+        });
+    }
+
+    /**
      * Check Redis connectivity and return service health status.
      *
      * @param Logger $logger

--- a/swagger.yml
+++ b/swagger.yml
@@ -89,23 +89,72 @@ paths:
       tags:
         - "api"
       consumes:
-        - "text/plain"
+        - "application/json"
       produces:
-        - "text/plain"
+        - "application/json"
       parameters:
         - in: "body"
           name: "body"
-          description: "Serialized secret to store in the server"
+          description: "JSON payload containing the encrypted secret and storage parameters"
           required: true
           schema:
-            type: "string"
+            type: "object"
+            required:
+              - "encrypted_secret"
+              - "ttl"
+              - "max_views"
+            properties:
+              encrypted_secret:
+                type: "string"
+                description: "Client-side encrypted secret payload"
+              ttl:
+                type: "integer"
+                description: "Time-to-live in seconds (1–604800)"
+                minimum: 1
+                maximum: 604800
+              max_views:
+                type: "integer"
+                description: "Maximum number of times the secret may be viewed"
+                minimum: 1
       responses:
         "201":
           description: "Created"
+          schema:
+            type: "object"
+            properties:
+              id:
+                type: "string"
+                description: "Unique identifier for the stored secret"
+                example: "a1b2c3d4e5f6"
+              expires_at:
+                type: "integer"
+                description: "Unix timestamp when the secret expires"
+                example: 1700000000
+              max_views:
+                type: "integer"
+                description: "Maximum number of allowed views"
+                example: 5
         "400":
-          description: "Bad Request"
+          description: "Bad Request — invalid or missing fields"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
         "413":
           description: "Payload Too Large"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+        "503":
+          description: "Service Unavailable — Redis unreachable"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."


### PR DESCRIPTION
## Summary

Implements the `POST /api/create` JSON API endpoint as described in [DIS-650](https://linear.app/displace-tech/issue/DIS-650/implement-post-apicreate-with-json-requestresponse).

## Changes

- **`server/src/JsonCreateRequest.php`** — New value object that parses and validates the JSON request body:
  - `encrypted_secret`: non-empty string (client-side encrypted payload)
  - `ttl`: integer, 1–604800 seconds
  - `max_views`: integer ≥ 1
- **`server/src/ServerRoutes.php`** — New `apiCreateSecret()` handler:
  - Reads and validates JSON body via `JsonCreateRequest::fromString()`
  - Generates a 12-char hex secret ID
  - Stores `secret:{id}` and `views:{id}` in Redis with the requested TTL
  - Returns `201 Created` JSON: `{"id": "...", "expires_at": <unix_ts>, "max_views": N}`
  - Returns `400` with JSON error detail on validation failure
  - Returns `503` on Redis error
- **`server/server.php`** — Registers `POST /api/create` route
- **`swagger.yml`** — Updates `/api/create` to reflect JSON request/response schema

## Acceptance Criteria

- [x] `POST /api/create` accepts JSON body with `encrypted_secret`, `ttl`, `max_views`
- [x] Validates TTL (max 604800s) and max_views (≥ 1)
- [x] Stores secret and view count in Redis with the requested TTL
- [x] Returns JSON response with `id`, `expires_at`, and `max_views`

Refs: DIS-650