### PR TITLE
DIS-652: Add Redis view count storage and decrement logic

### DIFF
--- a/server/src/CreateRequest.php
+++ b/server/src/CreateRequest.php
@@ -7,12 +7,14 @@ class CreateRequest
     protected string $salt;
     protected string $verifier;
     protected string $secret;
+    protected int $views;
 
-    public function __construct(string $salt, string $verifier, string $secret)
+    public function __construct(string $salt, string $verifier, string $secret, int $views = ViewCounter::UNLIMITED)
     {
         $this->salt = $salt;
         $this->verifier = $verifier;
         $this->secret = $secret;
+        $this->views = $views;
     }
 
     /**
@@ -36,6 +38,16 @@ class CreateRequest
     }
 
     /**
+     * Return the remaining view count, or ViewCounter::UNLIMITED (-1) for no limit.
+     *
+     * @return int
+     */
+    public function views(): int
+    {
+        return $this->views;
+    }
+
+    /**
      * Deserialize a request and create a new object from it.
      *
      * @param string $raw
@@ -48,13 +60,14 @@ class CreateRequest
     {
        $parts = explode('$', $raw);
 
-       if (sizeof($parts) !== 3) {
+       if (sizeof($parts) < 3 || sizeof($parts) > 4) {
            throw new \Exception('Invalid serialized request!');
        }
 
        $salt = hex2bin($parts[0]);
        $verifier = hex2bin($parts[1]);
        $secret = hex2bin($parts[2]);
+       $views = isset($parts[3]) ? (int) $parts[3] : ViewCounter::UNLIMITED;
 
        if (strlen($salt) !== 16) {
            throw new \Exception('Invalid salt length!');
@@ -64,6 +77,6 @@ class CreateRequest
            throw new \Exception('Invalid verifier length!');
        }
 
-       return new self($salt, $verifier, $secret);
+       return new self($salt, $verifier, $secret, $views);
     }
 }

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -80,9 +80,11 @@ class ServerRoutes
             $secretID = bin2hex(random_bytes(6));
             $secretKey = "secret:{$secretID}";
             $verifierKey = "verifier:{$secretID}";
+            $ttl = 24 * 60 * 60;
 
-            $redisClient->setex($verifierKey, 24 * 60 * 60, $secretRequest->verifier());
-            $redisClient->setex($secretKey, (24 * 60 * 60) + 30, $secretRequest->secret());
+            $redisClient->setex($verifierKey, $ttl, $secretRequest->verifier());
+            $redisClient->setex($secretKey, $ttl + 30, $secretRequest->secret());
+            ViewCounter::initialize($redisClient, $secretID, $secretRequest->views(), $ttl);
 
             $logger->info(sprintf('Created secret %s', $secretID));
 
@@ -157,6 +159,11 @@ class ServerRoutes
             if ($secret === null) {
                 $logger->error(sprintf('Secret %s was requested but was not found.', $secretID));
                 return new Response(Status::NOT_FOUND, ['content-type' => 'text/plain'], 'Not found or expired');
+            }
+
+            $remaining = ViewCounter::decrement($redisClient, $secretID);
+            if (ViewCounter::deleteIfExhausted($redisClient, $secretID, $remaining)) {
+                $logger->info(sprintf('Secret %s view limit reached; keys deleted.', $secretID));
             }
 
             return new Response(Status::OK, ['content-type' => 'text/plain'], $secret);

--- a/server/src/ViewCounter.php
+++ b/server/src/ViewCounter.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Swordfish\Server;
+
+use Predis\Client;
+
+class ViewCounter
+{
+    const UNLIMITED = -1;
+
+    /**
+     * Initialize the view counter for a secret with the given TTL.
+     * A views value of UNLIMITED (-1) stores the sentinel and skips decrement logic.
+     *
+     * @param Client $redis
+     * @param string $id     Secret ID
+     * @param int    $views  Remaining view count, or UNLIMITED (-1)
+     * @param int    $ttl    TTL in seconds, matching the secret's TTL
+     */
+    public static function initialize(Client $redis, string $id, int $views, int $ttl): void
+    {
+        $redis->setex("views:{$id}", $ttl, $views);
+    }
+
+    /**
+     * Decrement the view counter and return the new remaining count.
+     * Returns UNLIMITED (-1) without decrementing when the sentinel is stored.
+     *
+     * @param Client $redis
+     * @param string $id
+     * @return int  New remaining count, or UNLIMITED (-1)
+     */
+    public static function decrement(Client $redis, string $id): int
+    {
+        $current = (int) $redis->get("views:{$id}");
+
+        if ($current === self::UNLIMITED) {
+            return self::UNLIMITED;
+        }
+
+        return (int) $redis->decr("views:{$id}");
+    }
+
+    /**
+     * Atomically delete the secret, verifier, and views keys when the counter
+     * reaches zero. Returns true if keys were deleted, false otherwise.
+     *
+     * @param Client $redis
+     * @param string $id
+     * @param int    $remaining  Count returned by decrement()
+     * @return bool
+     */
+    public static function deleteIfExhausted(Client $redis, string $id, int $remaining): bool
+    {
+        if ($remaining !== 0) {
+            return false;
+        }
+
+        $redis->del(["secret:{$id}", "verifier:{$id}", "views:{$id}"]);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

Implements `views:{id}` Redis key storage and decrement logic for secret view limits.

Refs: [DIS-652](https://linear.app/displace-tech/issue/DIS-652/add-redis-view-count-storage-and-decrement-logic)

## Changes

### `ViewCounter` (new class)
- `initialize(Client, string $id, int $views, int $ttl)` — creates `views:{id}` with the same TTL as the verifier key
- `decrement(Client, string $id): int` — decrements the counter and returns the new remaining count; returns `-1` (UNLIMITED) without touching Redis when the sentinel is stored
- `deleteIfExhausted(Client, string $id, int $remaining): bool` — issues a single atomic `DEL` on `secret:{id}`, `verifier:{id}`, and `views:{id}` when `$remaining === 0`

### `CreateRequest`
- Accepts an optional 4th `$views` field in the serialized format (`hex(salt)$hex(verifier)$hex(secret)[$views]`)
- Defaults to `ViewCounter::UNLIMITED` (`-1`) when the field is absent — fully backward-compatible with existing clients
- Exposes a `views(): int` accessor

### `ServerRoutes`
- `createSecret`: calls `ViewCounter::initialize()` after storing the secret and verifier keys
- `retrieveSecret`: calls `ViewCounter::decrement()` after a successful retrieval, then `ViewCounter::deleteIfExhausted()` to clean up all three keys atomically when the limit is reached

## Acceptance Criteria

- [x] View count key is created alongside secret with matching TTL
- [x] Decrement returns updated count
- [x] When count reaches 0, secret and verifier keys are deleted atomically
- [x] `unlimited` handled via sentinel value `-1` (stored in key; skips decrement)