### PR TITLE
DIS-648: Support configurable TTL for secrets

### DIFF
--- a/server/src/CreateRequest.php
+++ b/server/src/CreateRequest.php
@@ -4,15 +4,20 @@ namespace Swordfish\Server;
 
 class CreateRequest
 {
+    const DEFAULT_TTL = 86400;
+    const MAX_TTL = 604800;
+
     protected string $salt;
     protected string $verifier;
     protected string $secret;
+    protected int $ttl;
 
-    public function __construct(string $salt, string $verifier, string $secret)
+    public function __construct(string $salt, string $verifier, string $secret, int $ttl = self::DEFAULT_TTL)
     {
         $this->salt = $salt;
         $this->verifier = $verifier;
         $this->secret = $secret;
+        $this->ttl = $ttl;
     }
 
     /**
@@ -36,6 +41,16 @@ class CreateRequest
     }
 
     /**
+     * Return the requested TTL in seconds for the secret.
+     *
+     * @return int
+     */
+    public function ttl(): int
+    {
+        return $this->ttl;
+    }
+
+    /**
      * Deserialize a request and create a new object from it.
      *
      * @param string $raw
@@ -48,7 +63,7 @@ class CreateRequest
     {
        $parts = explode('$', $raw);
 
-       if (sizeof($parts) !== 3) {
+       if (sizeof($parts) < 3 || sizeof($parts) > 4) {
            throw new \Exception('Invalid serialized request!');
        }
 
@@ -64,6 +79,14 @@ class CreateRequest
            throw new \Exception('Invalid verifier length!');
        }
 
-       return new self($salt, $verifier, $secret);
+       $ttl = self::DEFAULT_TTL;
+       if (sizeof($parts) === 4) {
+           $ttl = (int) $parts[3];
+           if ($ttl < 1 || $ttl > self::MAX_TTL) {
+               throw new \InvalidArgumentException(sprintf('TTL must be between 1 and %d seconds.', self::MAX_TTL));
+           }
+       }
+
+       return new self($salt, $verifier, $secret, $ttl);
     }
 }

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -72,6 +72,9 @@ class ServerRoutes
 
             try {
                 $secretRequest = CreateRequest::fromString($data);
+            } catch (\InvalidArgumentException $e) {
+                $logger->error('Invalid TTL in creation request: ' . $e->getMessage());
+                return new Response(Status::UNPROCESSABLE_ENTITY, ['content-type' => 'application/json'], json_encode(['error' => $e->getMessage()]));
             } catch (\Exception $e) {
                 $logger->error('Unable to decode creation request');
                 return new Response(Status::BAD_REQUEST, ['content-type' => 'text/plain'], 'Bad Request');
@@ -81,8 +84,9 @@ class ServerRoutes
             $secretKey = "secret:{$secretID}";
             $verifierKey = "verifier:{$secretID}";
 
-            $redisClient->setex($verifierKey, 24 * 60 * 60, $secretRequest->verifier());
-            $redisClient->setex($secretKey, (24 * 60 * 60) + 30, $secretRequest->secret());
+            $ttl = $secretRequest->ttl();
+            $redisClient->setex($verifierKey, $ttl, $secretRequest->verifier());
+            $redisClient->setex($secretKey, $ttl + 30, $secretRequest->secret());
 
             $logger->info(sprintf('Created secret %s', $secretID));
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -95,7 +95,9 @@ paths:
       parameters:
         - in: "body"
           name: "body"
-          description: "Serialized secret to store in the server"
+          description: |
+            Serialized secret to store in the server. Format: hex(salt)$hex(verifier)$hex(secret)[$ttl]
+            The optional TTL field specifies the secret lifetime in seconds (1–604800). Defaults to 86400.
           required: true
           schema:
             type: "string"
@@ -106,6 +108,8 @@ paths:
           description: "Bad Request"
         "413":
           description: "Payload Too Large"
+        "422":
+          description: "Unprocessable Entity — TTL out of range"
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."


### PR DESCRIPTION
## Summary

Implements configurable TTL for secrets as described in [DIS-648](https://linear.app/displace-tech/issue/DIS-648/support-configurable-ttl-for-secrets).

## Changes

### `server/src/CreateRequest.php`
- Added `DEFAULT_TTL` (86400) and `MAX_TTL` (604800) constants
- Added optional `$ttl` property and constructor parameter (defaults to `DEFAULT_TTL`)
- Added `ttl()` accessor method
- Updated `fromString()` to accept an optional 4th `$`-delimited field for TTL
- Validates TTL is between 1 and 604800; throws `\InvalidArgumentException` on invalid values

### `server/src/ServerRoutes.php`
- Updated `createSecret` handler to catch `\InvalidArgumentException` separately and return **422 Unprocessable Entity** with a JSON error body
- Verifier TTL is set to the requested TTL; secret TTL is `TTL + 30` (preserving the v1 30-second offset pattern)

### `swagger.yml`
- Documented the optional TTL field in the `/api/create` request body description
- Added `422` response code for out-of-range TTL

## Acceptance Criteria

- [x] Secrets are stored with the requested TTL
- [x] Verifier TTL is 30 seconds less than secret TTL
- [x] Invalid TTLs are rejected with an error (422)
- [x] Default is 86400s when not specified