### PR TITLE
DIS-651: Implement POST /api/retrieve with JSON request/response and view counting

### DIFF
--- a/server/server.php
+++ b/server/server.php
@@ -52,6 +52,7 @@ Amp\Loop::run(function () {
 
     $router->addRoute('POST', '/create', ServerRoutes::createSecret($logger, $redisClient));
     $router->addRoute('POST', '/retrieve', ServerRoutes::retrieveSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecretJson($logger, $redisClient));
 
     $router->setFallback($documentRoot);
 

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -162,4 +162,90 @@ class ServerRoutes
             return new Response(Status::OK, ['content-type' => 'text/plain'], $secret);
         });
     }
+
+    /**
+     * Handle JSON API requests to retrieve a secret.
+     *
+     * Accepts: {"id": "...", "verifier": "..."}
+     * Returns: {"encrypted_secret": "...", "views_remaining": N, "expires_at": T}
+     *
+     * Verifies the bcrypt-hashed verifier, decrements the view counter, and
+     * deletes all keys for the secret when views are exhausted.
+     *
+     * @param Logger $logger
+     * @param Client $redisClient
+     * @return CallableRequestHandler
+     */
+    public static function retrieveSecretJson(Logger $logger, Client $redisClient): CallableRequestHandler
+    {
+        return new CallableRequestHandler(function (Request $request) use ($logger, $redisClient) {
+            $data = yield $request->getBody()->read();
+
+            $parsed = json_decode($data, true);
+            if ($parsed === null || !isset($parsed['id'], $parsed['verifier'])) {
+                $logger->error('Unable to decode JSON retrieval request');
+                return new Response(
+                    Status::BAD_REQUEST,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Bad Request'])
+                );
+            }
+
+            $secretID    = $parsed['id'];
+            $verifier    = $parsed['verifier'];
+            $verifierKey = "json_verifier:{$secretID}";
+            $secretKey   = "json_secret:{$secretID}";
+            $viewsKey    = "json_views:{$secretID}";
+            $expiresKey  = "json_expires:{$secretID}";
+
+            $hash = $redisClient->get($verifierKey);
+            if ($hash === null) {
+                $logger->error(sprintf('JSON secret %s was requested but verification code was not found.', $secretID));
+                return new Response(
+                    Status::NOT_FOUND,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Not found or expired'])
+                );
+            }
+
+            if (!password_verify($verifier, $hash)) {
+                $logger->error(sprintf('JSON secret %s requested with an invalid verifier.', $secretID));
+                return new Response(
+                    Status::UNAUTHORIZED,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Invalid authorization'])
+                );
+            }
+
+            $encryptedSecret = $redisClient->get($secretKey);
+            if ($encryptedSecret === null) {
+                $logger->error(sprintf('JSON secret %s was requested but was not found.', $secretID));
+                return new Response(
+                    Status::NOT_FOUND,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Not found or expired'])
+                );
+            }
+
+            $expiresAt  = (int) $redisClient->get($expiresKey);
+            $viewsAfter = (int) $redisClient->decr($viewsKey);
+
+            if ($viewsAfter <= 0) {
+                $redisClient->del($secretKey, $verifierKey, $viewsKey, $expiresKey);
+                $logger->info(sprintf('JSON secret %s views exhausted; deleted all keys.', $secretID));
+            }
+
+            $logger->info(sprintf('Retrieved JSON secret %s (%d views remaining).', $secretID, max(0, $viewsAfter)));
+
+            return new Response(
+                Status::OK,
+                ['content-type' => 'application/json'],
+                json_encode([
+                    'encrypted_secret' => $encryptedSecret,
+                    'views_remaining'  => max(0, $viewsAfter),
+                    'expires_at'       => $expiresAt,
+                ])
+            );
+        });
+    }
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -112,22 +112,62 @@ paths:
       tags:
         - "api"
       consumes:
-        - "text/plain"
+        - "application/json"
       produces:
-        - "text/plain"
+        - "application/json"
       parameters:
         - in: "body"
           name: "body"
-          description: "Serialized authentication request for a stored secret"
+          description: "JSON authentication request for a stored secret"
           required: true
           schema:
-            type: "string"
+            type: "object"
+            required:
+              - "id"
+              - "verifier"
+            properties:
+              id:
+                type: "string"
+                description: "Secret ID returned at creation time"
+              verifier:
+                type: "string"
+                description: "Verifier string used to authenticate the request"
       responses:
         "200":
           description: "OK"
+          schema:
+            type: "object"
+            properties:
+              encrypted_secret:
+                type: "string"
+                description: "The encrypted secret payload"
+              views_remaining:
+                type: "integer"
+                description: "Number of views remaining after this retrieval"
+              expires_at:
+                type: "integer"
+                description: "Unix timestamp when the secret expires"
         "400":
           description: "Bad Request"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Bad Request"
         "401":
           description: "Unauthorized"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Invalid authorization"
         "404":
           description: "Not Found"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Not found or expired"


### PR DESCRIPTION
## Summary

Implements the `POST /api/retrieve` JSON API endpoint as described in [DIS-651](https://linear.app/displace-tech/issue/DIS-651/implement-post-apiretrieve-with-json-requestresponse-and-view-counting).

## Changes

- **`server/src/ServerRoutes.php`**: Added `retrieveSecretJson()` handler that:
  - Accepts `{id, verifier}` JSON body
  - Verifies the bcrypt-hashed verifier via `password_verify()`
  - Reads the encrypted secret, `expires_at`, and view counter from Redis
  - Decrements the view counter atomically with `DECR`
  - Deletes all keys (`json_secret:*`, `json_verifier:*`, `json_views:*`, `json_expires:*`) when views reach 0
  - Returns `{encrypted_secret, views_remaining, expires_at}` on success
  - Returns JSON error responses for bad request (400), unauthorized (401), and not found/expired (404)
- **`server/server.php`**: Registered the new route `POST /api/retrieve → ServerRoutes::retrieveSecretJson()`
- **`swagger.yml`**: Added the `POST /api/retrieve` endpoint to the OpenAPI spec

## Acceptance Criteria

- [x] `POST /api/retrieve` returns encrypted secret with `views_remaining` and `expires_at` on success
- [x] View counter decrements correctly
- [x] Secret is deleted when views reach 0
- [x] Error response returned for missing/expired secrets

Closes DIS-651