### PR TITLE
DIS-695: Migrate POST /create to POST /api/create with backward-compatible redirect

### DIFF
--- a/server/server.php
+++ b/server/server.php
@@ -50,7 +50,8 @@ Amp\Loop::run(function () {
     /**  Server back-end API                                  **/
     /***********************************************************/
 
-    $router->addRoute('POST', '/create', ServerRoutes::createSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/create', ServerRoutes::createSecret($logger, $redisClient));
+    $router->addRoute('POST', '/create', ServerRoutes::redirectCreate($logger));
     $router->addRoute('POST', '/retrieve', ServerRoutes::retrieveSecret($logger, $redisClient));
     $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecretJson($logger, $redisClient));
 

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -55,6 +55,20 @@ class ServerRoutes
     }
 
     /**
+     * Redirect POST /create to POST /api/create with a 307 Temporary Redirect.
+     *
+     * @param Logger $logger
+     * @return CallableRequestHandler
+     */
+    public static function redirectCreate(Logger $logger): CallableRequestHandler
+    {
+        return new CallableRequestHandler(function() use ($logger): Response {
+            $logger->info('Redirecting POST /create to POST /api/create');
+            return new Response(Status::TEMPORARY_REDIRECT, ['location' => '/api/create'], '');
+        });
+    }
+
+    /**
      * Process a secret creation request and attempt to create the secret.
      *
      * @param Logger $logger

--- a/swagger.yml
+++ b/swagger.yml
@@ -83,6 +83,25 @@ paths:
                 type: "string"
                 example: "Connection refused [tcp://redis:6379]"
 
+  /create:
+    post:
+      summary: "Create a new secret (deprecated — redirects to /api/create)."
+      tags:
+        - "api"
+      consumes:
+        - "text/plain"
+      produces:
+        - "text/plain"
+      parameters:
+        - in: "body"
+          name: "body"
+          description: "Serialized secret to store in the server."
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "307":
+          description: "Temporary Redirect to /api/create"
   /api/create:
     post:
       summary: "Create a new secret in the datastore."


### PR DESCRIPTION
## Summary

Resolves [DIS-695](https://linear.app/displace-tech/issue/DIS-695/migrate-post-create-to-post-apicreate-with-backward-compatible).

## Changes

- **`POST /api/create`** is now the canonical secret creation endpoint, handled by `ServerRoutes::createSecret()`.
- **`POST /create`** now returns a `307 Temporary Redirect` to `/api/create`, preserving the HTTP method so existing clients continue to work without modification.
- Added `ServerRoutes::redirectCreate()` handler that issues the 307 response.
- Updated `swagger.yml` to document the `/create` redirect alongside the existing `/api/create` spec.

## Acceptance Criteria

- [x] `POST /api/create` works for secret creation.
- [x] `POST /create` redirects (307) to `/api/create` and continues to work for existing clients.