### PR TITLE
DIS-698: Add Keel annotations to Helm chart for automated deployment

### DIFF
--- a/helm/swordfish/templates/deployment.yaml
+++ b/helm/swordfish/templates/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
   annotations:
     keel.sh/policy: {{ .Values.keel.policy | quote }}
     keel.sh/trigger: {{ .Values.keel.trigger | quote }}
+    {{- if eq .Values.keel.trigger "poll" }}
     keel.sh/pollSchedule: {{ .Values.keel.pollSchedule | quote }}
+    {{- end }}
     keel.sh/match-tag: {{ .Values.keel.matchTag | quote }}
 spec:
   replicas: {{ .Values.server.replicaCount }}


### PR DESCRIPTION
## Summary

Configures Keel annotations on the Helm chart `Deployment` so that Keel automatically detects new images pushed to GHCR and triggers a rollout.

## Changes

- Keel annotations (`keel.sh/policy`, `keel.sh/trigger`, `keel.sh/pollSchedule`, `keel.sh/match-tag`) are set on the `Deployment` metadata and driven by `values.yaml`
- Made `keel.sh/pollSchedule` conditional on `trigger: poll` — the annotation is only rendered when polling is the active trigger type, avoiding misleading configuration for other trigger modes
- Default values: `policy: force`, `trigger: poll`, `pollSchedule: @every 5m`, `matchTag: true` — appropriate for GHCR `latest`-tag deployments

## Acceptance Criteria

- [x] Helm chart `Deployment` has Keel annotations
- [x] When a new image is pushed to GHCR, Keel detects it (via poll every 5 minutes) and triggers a rollout

Closes DIS-698
Ref: https://linear.app/displace-tech/issue/DIS-698/add-keel-annotations-to-helm-chart-for-automated-deployment