### PR TITLE
DIS-697: Add GET /health endpoint with Redis connectivity check

### DIFF
--- a/server/tests/HealthCheckTest.php
+++ b/server/tests/HealthCheckTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use Amp\Http\Server\Driver\Client;
+use Amp\Http\Server\Request;
+use Amp\Http\Status;
+use League\Uri\Http;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Predis\Connection\ConnectionException;
+use Swordfish\Server\ServerRoutes;
+
+class HealthCheckTest extends TestCase
+{
+    private function makeRequest(): Request
+    {
+        $client = $this->createMock(Client::class);
+        return new Request($client, 'GET', Http::new('http://localhost/health'));
+    }
+
+    private function makeRedisMock(): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['ping'])
+            ->getMock();
+    }
+
+    public function testHealthCheckReturns200WhenRedisIsReachable(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->once())->method('ping');
+
+        $handler  = ServerRoutes::healthCheck($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+
+        $this->assertSame(Status::OK, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body = \Amp\Promise\wait($response->getBody()->read());
+        $this->assertSame(['status' => 'ok'], json_decode($body, true));
+    }
+
+    public function testHealthCheckReturns503WhenRedisIsUnreachable(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->method('ping')->willThrowException(
+            new \RuntimeException('Connection refused')
+        );
+
+        $handler  = ServerRoutes::healthCheck($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+
+        $this->assertSame(Status::SERVICE_UNAVAILABLE, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertSame('error', $parsed['status']);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `GET /health` endpoint that checks Redis connectivity and returns an appropriate status response.

Closes / references: [DIS-697](https://linear.app/displace-tech/issue/DIS-697/add-get-health-endpoint-with-redis-connectivity-check)

## Changes

The health endpoint and its route registration were already present in the codebase. This PR adds PHPUnit tests to verify the behaviour described in the acceptance criteria:

- `GET /health` → `200 OK` with `{"status": "ok"}` when Redis is reachable
- `GET /health` → `503 Service Unavailable` with `{"status": "error"}` when Redis is unreachable

### Files changed

| File | Change |
|---|---|
| `server/src/ServerRoutes.php` | `healthCheck()` handler (already implemented) |
| `server/server.php` | Route registration `GET /health` (already implemented) |
| `swagger.yml` | OpenAPI spec for `/health` (already documented) |
| `server/tests/HealthCheckTest.php` | **New** — PHPUnit tests for both success and failure paths |

## Testing

```bash
cd server && composer install && ./vendor/bin/phpunit
```

All 3 tests pass (smoke test + 2 health-check tests).