### PR TITLE
DIS-706: Add SPA build step to GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,12 @@ on:
   push:
     paths:
       - 'server/**'
+      - 'frontend/**'
       - '.github/workflows/build.yml'
   pull_request:
     paths:
       - 'server/**'
+      - 'frontend/**'
       - '.github/workflows/build.yml'
 
 env:
@@ -24,6 +26,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build SPA
+        working-directory: frontend
+        run: npm run build
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

Closes/references: [DIS-706](https://linear.app/displace-tech/issue/DIS-706/add-spa-build-step-to-github-actions-ci-pipeline)

Adds a frontend build step to the CI pipeline so that the React SPA is compiled and its assets are included in the Docker image.

## Changes

- **Trigger paths**: Added `frontend/**` to both `push` and `pull_request` path filters so that frontend changes correctly trigger a new image build.
- **Node.js setup**: Uses `actions/setup-node@v4` with Node 20 and npm dependency caching keyed on `frontend/package-lock.json`.
- **Install step**: Runs `npm ci` in the `frontend/` directory for a clean, reproducible install.
- **Build step**: Runs `npm run build` (Vite) in the `frontend/` directory. Per `vite.config.js`, output goes to `../server/static/`, which is already inside the Docker build context (`./server`).

These steps run before Docker Buildx is set up, ensuring built assets are present when the image is assembled.

## Acceptance Criteria

- [x] CI pipeline installs frontend dependencies and runs `npm run build` successfully.
- [x] Built assets are included in the Docker image (via `server/static/`, which is part of the `./server` build context).