### PR TITLE
DIS-703: Add liveness/readiness probes to Helm chart Deployment

### DIFF
--- a/helm/swordfish/templates/deployment.yaml
+++ b/helm/swordfish/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             - name: http
               containerPort: {{ .Values.server.service.port }}
               protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.server.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.server.readinessProbe | nindent 12 }}
           env:
             - name: SERVER_PORT
               value: {{ .Values.server.env.SERVER_PORT | quote }}

--- a/helm/swordfish/values.yaml
+++ b/helm/swordfish/values.yaml
@@ -28,6 +28,22 @@ server:
     limits:
       cpu: 200m
       memory: 256Mi
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## Summary

Closes / references [DIS-703](https://linear.app/displace-tech/issue/DIS-703/add-livenessreadiness-probes-to-helm-chart-deployment).

Adds `livenessProbe` and `readinessProbe` to the swordfish container spec in the Helm chart Deployment template. Both probes hit `GET /health` via the named `http` port.

## Probe configuration

| Field | livenessProbe | readinessProbe |
|---|---|---|
| `httpGet.path` | `/health` | `/health` |
| `httpGet.port` | `http` | `http` |
| `initialDelaySeconds` | 10 | 5 |
| `periodSeconds` | 15 | 10 |
| `timeoutSeconds` | 5 | 5 |
| `failureThreshold` | 3 | 3 |

All values are set in `values.yaml` under `server.livenessProbe` / `server.readinessProbe` and are fully overridable per-deployment.

## Testing

- `helm lint helm/swordfish/` passes with 0 failures
- `helm template` renders both probes correctly against the `http` named port