### PR TITLE
DIS-707: Add API client module for communicating with the backend

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,60 @@
+/**
+ * @typedef {Object} RetrieveResponse
+ * @property {string} encrypted_secret - The encrypted secret payload
+ * @property {number} views_remaining  - Number of views remaining after this retrieval
+ * @property {number} expires_at       - Unix timestamp when the secret expires
+ */
+
+/**
+ * Create a new secret in the datastore.
+ *
+ * Sends a plain-text payload to POST /api/create in the format:
+ *   hex(salt)$hex(verifier)$hex(secret)[$ttl]
+ *
+ * @param {string} payload - Serialized secret string
+ * @returns {Promise<string>} The secret ID assigned by the server
+ * @throws {Error} On HTTP error or network failure
+ */
+export async function createSecret(payload) {
+  const response = await fetch('/api/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/plain' },
+    body: payload,
+  })
+
+  if (!response.ok) {
+    const contentType = response.headers.get('content-type') ?? ''
+    if (contentType.includes('application/json')) {
+      const data = await response.json()
+      throw new Error(data.error ?? response.statusText)
+    }
+    throw new Error(response.statusText)
+  }
+
+  return response.text()
+}
+
+/**
+ * Retrieve a secret from the datastore.
+ *
+ * Sends a JSON request to POST /api/retrieve and returns the parsed response.
+ *
+ * @param {string} id       - Secret ID returned at creation time
+ * @param {string} verifier - Verifier string used to authenticate the request
+ * @returns {Promise<RetrieveResponse>} The encrypted secret payload and metadata
+ * @throws {Error} On HTTP error or network failure
+ */
+export async function retrieveSecret(id, verifier) {
+  const response = await fetch('/api/retrieve', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, verifier }),
+  })
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.error ?? response.statusText)
+  }
+
+  return response.json()
+}


### PR DESCRIPTION
## Summary

Implements the API client module described in [DIS-707](https://linear.app/displace-tech/issue/DIS-707/create-api-client-module-for-communicating-with-the-backend).

## Changes

- Adds `frontend/src/api.js` with two named exports:
  - `createSecret(payload)` — POSTs a plain-text serialized secret to `POST /api/create` and returns the assigned secret ID
  - `retrieveSecret(id, verifier)` — POSTs a JSON authentication request to `POST /api/retrieve` and returns the parsed `{ encrypted_secret, views_remaining, expires_at }` response
- Both functions handle HTTP error responses gracefully, extracting `error` fields from JSON bodies where available
- Functions are annotated with JSDoc types for use by React components

## Acceptance Criteria

- [x] API client module correctly sends JSON requests to `/api/retrieve` and parses JSON responses
- [x] API client module correctly sends plain-text requests to `/api/create` and parses the response
- [x] Error responses are handled gracefully
- [x] Typed (JSDoc) functions exported for use by React components
- [x] Lint passes (`npm run lint`)