### PR TITLE
DIS-701: Switch POST /api/create to JSON request/response format

### DIFF
--- a/server/server.php
+++ b/server/server.php
@@ -50,7 +50,7 @@ Amp\Loop::run(function () {
     /**  Server back-end API                                  **/
     /***********************************************************/
 
-    $router->addRoute('POST', '/api/create', ServerRoutes::createSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/create', ServerRoutes::createSecretJson($logger, $redisClient));
     $router->addRoute('POST', '/create', ServerRoutes::redirectCreate($logger));
     $router->addRoute('POST', '/retrieve', ServerRoutes::retrieveSecret($logger, $redisClient));
     $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecretJson($logger, $redisClient));

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -69,42 +69,79 @@ class ServerRoutes
     }
 
     /**
-     * Process a secret creation request and attempt to create the secret.
+     * Process a JSON secret creation request and store the secret.
+     *
+     * Accepts: {"encrypted_secret": "...", "ttl": 86400, "max_views": 3}
+     * Returns: {"id": "...", "expires_at": <unix timestamp>, "max_views": 3}
      *
      * @param Logger $logger
      * @param Client $redisClient
-     * @return Callable
+     * @return CallableRequestHandler
      */
-    public static function createSecret(Logger $logger, Client $redisClient): CallableRequestHandler
+    public static function createSecretJson(Logger $logger, Client $redisClient): CallableRequestHandler
     {
-        return new CallableRequestHandler(function(Request $request) use ($logger, $redisClient) {
+        return new CallableRequestHandler(function (Request $request) use ($logger, $redisClient) {
             $data = yield $request->getBody()->read();
             if (strlen($data) > 100 * 1000) {
                 $logger->error('Message payload too large!');
-                return new Response(Status::PAYLOAD_TOO_LARGE, ['content-type' => 'text/plain'], 'Payload Too Large');
+                return new Response(
+                    Status::PAYLOAD_TOO_LARGE,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Payload Too Large'])
+                );
             }
 
-            try {
-                $secretRequest = CreateRequest::fromString($data);
-            } catch (\InvalidArgumentException $e) {
-                $logger->error('Invalid TTL in creation request: ' . $e->getMessage());
-                return new Response(Status::UNPROCESSABLE_ENTITY, ['content-type' => 'application/json'], json_encode(['error' => $e->getMessage()]));
-            } catch (\Exception $e) {
-                $logger->error('Unable to decode creation request');
-                return new Response(Status::BAD_REQUEST, ['content-type' => 'text/plain'], 'Bad Request');
+            $parsed = json_decode($data, true);
+            if ($parsed === null || !isset($parsed['encrypted_secret']) || !is_string($parsed['encrypted_secret']) || $parsed['encrypted_secret'] === '') {
+                $logger->error('Invalid JSON creation request: missing or empty encrypted_secret');
+                return new Response(
+                    Status::BAD_REQUEST,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Bad Request'])
+                );
             }
 
-            $secretID = bin2hex(random_bytes(6));
-            $secretKey = "secret:{$secretID}";
-            $verifierKey = "verifier:{$secretID}";
+            $ttl = isset($parsed['ttl']) ? (int) $parsed['ttl'] : CreateRequest::DEFAULT_TTL;
+            if ($ttl < 1 || $ttl > CreateRequest::MAX_TTL) {
+                $logger->error(sprintf('Invalid TTL in JSON creation request: %d', $ttl));
+                return new Response(
+                    Status::UNPROCESSABLE_ENTITY,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => sprintf('TTL must be between 1 and %d seconds.', CreateRequest::MAX_TTL)])
+                );
+            }
 
-            $ttl = $secretRequest->ttl();
-            $redisClient->setex($verifierKey, $ttl, $secretRequest->verifier());
-            $redisClient->setex($secretKey, $ttl + 30, $secretRequest->secret());
+            $maxViews = isset($parsed['max_views']) ? (int) $parsed['max_views'] : 1;
+            if ($maxViews < 1) {
+                $logger->error(sprintf('Invalid max_views in JSON creation request: %d', $maxViews));
+                return new Response(
+                    Status::UNPROCESSABLE_ENTITY,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'max_views must be at least 1.'])
+                );
+            }
 
-            $logger->info(sprintf('Created secret %s', $secretID));
+            $secretID   = bin2hex(random_bytes(6));
+            $secretKey  = "json_secret:{$secretID}";
+            $viewsKey   = "json_views:{$secretID}";
+            $expiresKey = "json_expires:{$secretID}";
+            $expiresAt  = time() + $ttl;
 
-            return new Response(Status::CREATED, ['content-type' => 'text/plain'], $secretID);
+            $redisClient->setex($secretKey, $ttl, $parsed['encrypted_secret']);
+            $redisClient->setex($viewsKey, $ttl, (string) $maxViews);
+            $redisClient->setex($expiresKey, $ttl, (string) $expiresAt);
+
+            $logger->info(sprintf('Created JSON secret %s (ttl=%d, max_views=%d)', $secretID, $ttl, $maxViews));
+
+            return new Response(
+                Status::CREATED,
+                ['content-type' => 'application/json'],
+                json_encode([
+                    'id'        => $secretID,
+                    'expires_at' => $expiresAt,
+                    'max_views' => $maxViews,
+                ])
+            );
         });
     }
 

--- a/server/tests/Unit/CreateSecretJsonTest.php
+++ b/server/tests/Unit/CreateSecretJsonTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use Amp\ByteStream\InMemoryStream;
+use Amp\Http\Server\Driver\Client;
+use Amp\Http\Server\Request;
+use Amp\Http\Status;
+use League\Uri\Http;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\ServerRoutes;
+
+class CreateSecretJsonTest extends TestCase
+{
+    private function makeRequest(string $body): Request
+    {
+        $client = $this->createMock(Client::class);
+        return new Request(
+            $client,
+            'POST',
+            Http::new('http://localhost/api/create'),
+            ['content-type' => 'application/json'],
+            new InMemoryStream($body)
+        );
+    }
+
+    private function makeRedisMock(): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['setex'])
+            ->getMock();
+    }
+
+    public function testReturns201WithValidPayload(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->exactly(3))->method('setex');
+
+        $handler  = ServerRoutes::createSecretJson($logger, $redis);
+        $body     = json_encode(['encrypted_secret' => 'abc123', 'ttl' => 3600, 'max_views' => 2]);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($body)));
+
+        $this->assertSame(Status::CREATED, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $parsed = json_decode(\Amp\Promise\wait($response->getBody()->read()), true);
+        $this->assertArrayHasKey('id', $parsed);
+        $this->assertArrayHasKey('expires_at', $parsed);
+        $this->assertArrayHasKey('max_views', $parsed);
+        $this->assertSame(2, $parsed['max_views']);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{12}$/', $parsed['id']);
+    }
+
+    public function testDefaultsTtlAndMaxViews(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->exactly(3))->method('setex');
+
+        $handler  = ServerRoutes::createSecretJson($logger, $redis);
+        $body     = json_encode(['encrypted_secret' => 'abc123']);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($body)));
+
+        $this->assertSame(Status::CREATED, $response->getStatus());
+
+        $parsed = json_decode(\Amp\Promise\wait($response->getBody()->read()), true);
+        $this->assertSame(1, $parsed['max_views']);
+        $this->assertGreaterThan(time(), $parsed['expires_at']);
+    }
+
+    public function testReturns400WhenBodyIsNotJson(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->never())->method('setex');
+
+        $handler  = ServerRoutes::createSecretJson($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest('not-json')));
+
+        $this->assertSame(Status::BAD_REQUEST, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+    }
+
+    public function testReturns400WhenEncryptedSecretIsMissing(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->never())->method('setex');
+
+        $handler  = ServerRoutes::createSecretJson($logger, $redis);
+        $body     = json_encode(['ttl' => 3600]);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($body)));
+
+        $this->assertSame(Status::BAD_REQUEST, $response->getStatus());
+    }
+
+    public function testReturns400WhenEncryptedSecretIsEmpty(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->never())->method('setex');
+
+        $handler  = ServerRoutes::createSecretJson($logger, $redis);
+        $body     = json_encode(['encrypted_secret' => '']);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($body)));
+
+        $this->assertSame(Status::BAD_REQUEST, $response->getStatus());
+    }
+
+    public function testReturns422WhenTtlIsOutOfRange(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->never())->method('setex');
+
+        $handler  = ServerRoutes::createSecretJson($logger, $redis);
+        $body     = json_encode(['encrypted_secret' => 'abc123', 'ttl' => 999999]);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($body)));
+
+        $this->assertSame(Status::UNPROCESSABLE_ENTITY, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+    }
+
+    public function testReturns422WhenTtlIsZero(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->never())->method('setex');
+
+        $handler  = ServerRoutes::createSecretJson($logger, $redis);
+        $body     = json_encode(['encrypted_secret' => 'abc123', 'ttl' => 0]);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($body)));
+
+        $this->assertSame(Status::UNPROCESSABLE_ENTITY, $response->getStatus());
+    }
+
+    public function testReturns422WhenMaxViewsIsZero(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->never())->method('setex');
+
+        $handler  = ServerRoutes::createSecretJson($logger, $redis);
+        $body     = json_encode(['encrypted_secret' => 'abc123', 'max_views' => 0]);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($body)));
+
+        $this->assertSame(Status::UNPROCESSABLE_ENTITY, $response->getStatus());
+    }
+}

--- a/swagger.yml
+++ b/swagger.yml
@@ -108,27 +108,69 @@ paths:
       tags:
         - "api"
       consumes:
-        - "text/plain"
+        - "application/json"
       produces:
-        - "text/plain"
+        - "application/json"
       parameters:
         - in: "body"
           name: "body"
-          description: |
-            Serialized secret to store in the server. Format: hex(salt)$hex(verifier)$hex(secret)[$ttl]
-            The optional TTL field specifies the secret lifetime in seconds (1–604800). Defaults to 86400.
+          description: "JSON payload containing the encrypted secret and optional metadata."
           required: true
           schema:
-            type: "string"
+            type: "object"
+            required:
+              - "encrypted_secret"
+            properties:
+              encrypted_secret:
+                type: "string"
+                description: "The client-side encrypted secret payload."
+              ttl:
+                type: "integer"
+                description: "Secret lifetime in seconds (1–604800). Defaults to 86400."
+                default: 86400
+              max_views:
+                type: "integer"
+                description: "Maximum number of times the secret may be retrieved. Defaults to 1."
+                default: 1
       responses:
         "201":
           description: "Created"
+          schema:
+            type: "object"
+            properties:
+              id:
+                type: "string"
+                description: "Unique identifier for the stored secret."
+              expires_at:
+                type: "integer"
+                description: "Unix timestamp when the secret expires."
+              max_views:
+                type: "integer"
+                description: "Maximum number of retrievals allowed."
         "400":
           description: "Bad Request"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Bad Request"
         "413":
           description: "Payload Too Large"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Payload Too Large"
         "422":
-          description: "Unprocessable Entity — TTL out of range"
+          description: "Unprocessable Entity — TTL or max_views out of range"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "TTL must be between 1 and 604800 seconds."
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."


### PR DESCRIPTION
Closes / references: https://linear.app/displace-tech/issue/DIS-701/switch-post-apicreate-to-json-requestresponse-format

## Summary

Switches `POST /api/create` from the legacy `text/plain` wire format to a JSON request/response contract.

### Request
```json
{"encrypted_secret": "...", "ttl": 86400, "max_views": 3}
```

### Response (201 Created)
```json
{"id": "...", "expires_at": 1234567890, "max_views": 3}
```

## Changes

- **`server/src/ServerRoutes.php`** — Replaces `createSecret` with `createSecretJson`. The new handler:
  - Parses and validates the JSON body (`encrypted_secret` required; `ttl` 1–604800, default 86400; `max_views` ≥ 1, default 1)
  - Stores the secret in Redis under `json_secret:`, `json_views:`, and `json_expires:` keys (consistent with the existing `retrieveSecretJson` handler)
  - Returns `{id, expires_at, max_views}` JSON on `201 Created`
  - Returns structured JSON error bodies for `400`, `413`, and `422` responses
- **`server/server.php`** — Wires `/api/create` to the new `createSecretJson` handler; the `POST /create → /api/create` redirect remains in place for backward compatibility
- **`server/tests/Unit/CreateSecretJsonTest.php`** — Unit tests covering the success path, default values, and all validation error cases (missing/empty `encrypted_secret`, TTL out of range, `max_views` < 1, non-JSON body)
- **`swagger.yml`** — Documents the updated JSON contract for `POST /api/create`
