### PR TITLE
DIS-741: Set up PHPUnit test framework

### DIFF
--- a/server/phpunit.xml
+++ b/server/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true">
     <testsuites>
         <testsuite name="Unit">

--- a/server/tests/bootstrap.php
+++ b/server/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Summary

Completes the PHPUnit test framework setup for the server package.

Resolves [DIS-741](https://linear.app/displace-tech/issue/DIS-741/set-up-phpunit-test-framework).

## Changes

- Add `tests/bootstrap.php` — requires `vendor/autoload.php` so PHPUnit has a clean, explicit entry point
- Update `phpunit.xml` `bootstrap` attribute to reference `tests/bootstrap.php` instead of `vendor/autoload.php` directly

## Existing infrastructure (already on `main`)

- `phpunit/phpunit ^11.0` in `require-dev`
- `composer test` script wired to `phpunit`
- `phpunit.xml` with Unit and Integration test suites and source coverage config
- `tests/Unit/SmokeTest.php` — trivial smoke test (`assertTrue(true)`)
- `tests/Unit/HealthCheckTest.php` — tests for the `/health` endpoint
- `tests/Unit/SpaFallbackTest.php` — tests for the SPA fallback handler

## Acceptance criteria

- [x] `composer test` (and `vendor/bin/phpunit`) executes at least one passing test
- [x] `phpunit.xml` is committed

```
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.18
Configuration: server/phpunit.xml

DD....                                                              6 / 6 (100%)

Time: 00:00.036, Memory: 12.00 MB

OK, but there were issues!
Tests: 6, Assertions: 14, Deprecations: 4, PHPUnit Deprecations: 2.
```

> The 4 deprecations are from third-party vendor libraries (predis, amphp) on PHP 8.4 — not from project code.