### PR TITLE
DIS-787: Add liveness/readiness probes to Helm chart

### DIFF
--- a/helm/swordfish/values.yaml
+++ b/helm/swordfish/values.yaml
@@ -32,8 +32,8 @@ server:
     httpGet:
       path: /health
       port: http
-    initialDelaySeconds: 10
-    periodSeconds: 15
+    initialDelaySeconds: 30
+    periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
   readinessProbe:
@@ -41,7 +41,7 @@ server:
       path: /health
       port: http
     initialDelaySeconds: 5
-    periodSeconds: 10
+    periodSeconds: 5
     timeoutSeconds: 5
     failureThreshold: 3
   nodeSelector: {}


### PR DESCRIPTION
## Summary

Updates the Helm chart `values.yaml` to set liveness and readiness probe thresholds that meet the acceptance criteria for [DIS-787](https://linear.app/displace-tech/issue/DIS-787/add-livenessreadiness-probes-to-helm-chart).

The `deployment.yaml` template already had the probe stanzas wired up via `{{ toYaml .Values.server.livenessProbe }}` / `{{ toYaml .Values.server.readinessProbe }}`; only the default values needed correction.

## Changes

| Probe | Field | Before | After |
|---|---|---|---|
| liveness | `initialDelaySeconds` | 10 | **30** |
| liveness | `periodSeconds` | 15 | **10** |
| readiness | `periodSeconds` | 10 | **5** |

## Acceptance Criteria

- [x] Liveness probe: `GET /health`, 30 s initial delay, 10 s period
- [x] Readiness probe: `GET /health`, 5 s initial delay, 5 s period

Closes DIS-787