### PR TITLE
DIS-789: Add PHPUnit test step to GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,45 @@ env:
   IMAGE_NAME: ${{ github.repository }}/server
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pcntl
+          coverage: none
+
+      - name: Install Composer dependencies
+        working-directory: server
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit tests
+        working-directory: server
+        run: vendor/bin/phpunit
+        env:
+          REDIS_HOST: 127.0.0.1
+          REDIS_PORT: 6379
+
   build:
     runs-on: ubuntu-latest
+    needs: test
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

Adds a PHPUnit test job to the GitHub Actions CI pipeline before the Docker image build, as required by [DIS-789](https://linear.app/displace-tech/issue/DIS-789/add-phpunit-test-step-to-github-actions-ci-pipeline).

## Changes

- Added a `test` job to `.github/workflows/build.yml` that:
  - Spins up a Redis 7 service container (with health checks)
  - Sets up PHP 8.4 with the `pcntl` extension
  - Installs Composer dependencies
  - Runs `vendor/bin/phpunit` with `REDIS_HOST`/`REDIS_PORT` env vars available
- Added `needs: test` to the `build` job so the Docker image is only built after all tests pass

## Acceptance Criteria

- [x] CI pipeline runs PHPUnit tests with a Redis service container
- [x] Pipeline fails if any test fails