### PR TITLE
DIS-798: Add npm test step to CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,10 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: Run frontend tests
+        working-directory: frontend
+        run: npm test
+
       - name: Build SPA
         working-directory: frontend
         run: npm run build


### PR DESCRIPTION
## Summary

Adds the missing `npm test` step to the GitHub Actions CI pipeline, completing the frontend CI coverage for DIS-798.

## Changes

- Added **Run frontend tests** step in the `build` job, between `npm ci` and `npm run build`
- Runs `npm test` (i.e. `vitest run`) in `frontend/`
- The job already had Node.js setup, dependency install, SPA build, and Docker build/push; this fills the gap

## Acceptance Criteria

- [x] CI pipeline runs frontend tests (vitest) ✅
- [x] CI pipeline builds the SPA ✅ (was already present)
- [x] Built assets are included in the Docker image ✅ (build runs before Docker step)
- [x] Pipeline fails if frontend tests or build fail ✅ (GitHub Actions fails the job on non-zero exit)

Closes DIS-798: https://linear.app/displace-tech/issue/DIS-798/add-spa-build-step-to-github-actions-ci-pipeline