### PR TITLE
DIS-796: Implement JSON request/response format for POST /api/create

### DIFF
--- a/server/src/SecretService.php
+++ b/server/src/SecretService.php
@@ -31,6 +31,45 @@ class SecretService
     }
 
     /**
+     * Store a new JSON-API secret in Redis.
+     *
+     * Generates a random 12-character hex ID, stores the bcrypt-hashed verifier,
+     * the encrypted secret payload, the expiry timestamp, and (if bounded) the
+     * view counter — all keyed under the json_* namespace so they are compatible
+     * with retrieveJson().
+     *
+     * @param string   $encryptedSecret Client-side AES-GCM ciphertext (hex-encoded)
+     * @param string   $verifier        Plain-text verifier; bcrypt-hashed before storage
+     * @param int      $ttl             Lifetime in seconds
+     * @param int|null $maxViews        Maximum retrieval count, or null for unlimited
+     * @return array{id: string, expires_at: string, max_views: int|null}
+     */
+    public function createJson(string $encryptedSecret, string $verifier, int $ttl, ?int $maxViews): array
+    {
+        $secretID    = bin2hex(random_bytes(6));
+        $verifierKey = "json_verifier:{$secretID}";
+        $secretKey   = "json_secret:{$secretID}";
+        $viewsKey    = "json_views:{$secretID}";
+        $expiresKey  = "json_expires:{$secretID}";
+
+        $expiresAt = time() + $ttl;
+
+        $this->redis->setex($verifierKey, $ttl, password_hash($verifier, PASSWORD_DEFAULT));
+        $this->redis->setex($secretKey, $ttl + 30, $encryptedSecret);
+        $this->redis->setex($expiresKey, $ttl + 30, (string) $expiresAt);
+
+        if ($maxViews !== null) {
+            $this->redis->setex($viewsKey, $ttl, (string) $maxViews);
+        }
+
+        return [
+            'id'         => $secretID,
+            'expires_at' => (new \DateTimeImmutable("@{$expiresAt}"))->format(\DateTimeInterface::ATOM),
+            'max_views'  => $maxViews,
+        ];
+    }
+
+    /**
      * Retrieve a v1 secret after verifying the supplied password.
      *
      * @param string $secretID

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -99,8 +99,19 @@ class ServerRoutes
         });
     }
 
+    private const ALLOWED_TTLS       = [3600, 86400, 604800];
+    private const ALLOWED_MAX_VIEWS  = [1, 5, 10];
+    private const DEFAULT_TTL        = 86400;
+
     /**
-     * Process a secret creation request and attempt to create the secret.
+     * Process a JSON secret creation request, validate inputs, store the secret,
+     * and return a JSON response with id, expires_at (ISO 8601), and max_views.
+     *
+     * Accepted JSON fields:
+     *   - encrypted_secret (string, required)
+     *   - verifier         (string, required)
+     *   - ttl              (int, optional, default 86400; must be one of 3600|86400|604800)
+     *   - max_views        (int|null, optional, default null; must be one of 1|5|10|null)
      *
      * @param Logger $logger
      * @param Client $redisClient
@@ -113,23 +124,70 @@ class ServerRoutes
             $data = yield $request->getBody()->read();
             if (strlen($data) > 100 * 1000) {
                 $logger->error('Message payload too large!');
-                return new Response(Status::PAYLOAD_TOO_LARGE, ['content-type' => 'text/plain'], 'Payload Too Large');
+                return new Response(
+                    Status::PAYLOAD_TOO_LARGE,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Payload Too Large'])
+                );
             }
 
-            try {
-                $secretRequest = CreateRequest::fromString($data);
-            } catch (\InvalidArgumentException $e) {
-                $logger->error('Invalid TTL in creation request: ' . $e->getMessage());
-                return new Response(Status::UNPROCESSABLE_ENTITY, ['content-type' => 'application/json'], json_encode(['error' => $e->getMessage()]));
-            } catch (\Exception $e) {
-                $logger->error('Unable to decode creation request');
-                return new Response(Status::BAD_REQUEST, ['content-type' => 'text/plain'], 'Bad Request');
+            $parsed = json_decode($data, true);
+            if ($parsed === null || !isset($parsed['encrypted_secret'], $parsed['verifier'])) {
+                $logger->error('Unable to decode JSON creation request');
+                return new Response(
+                    Status::BAD_REQUEST,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Bad Request'])
+                );
             }
 
-            $secretID = $service->create($secretRequest);
-            $logger->info(sprintf('Created secret %s', $secretID));
+            $encryptedSecret = $parsed['encrypted_secret'];
+            $verifier        = $parsed['verifier'];
+            $ttl             = $parsed['ttl'] ?? self::DEFAULT_TTL;
+            $maxViews        = array_key_exists('max_views', $parsed) ? $parsed['max_views'] : null;
 
-            return new Response(Status::CREATED, ['content-type' => 'text/plain'], $secretID);
+            if (!is_string($encryptedSecret) || $encryptedSecret === '') {
+                return new Response(
+                    Status::BAD_REQUEST,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'encrypted_secret must be a non-empty string'])
+                );
+            }
+
+            if (!is_string($verifier) || $verifier === '') {
+                return new Response(
+                    Status::BAD_REQUEST,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'verifier must be a non-empty string'])
+                );
+            }
+
+            if (!is_int($ttl) || !in_array($ttl, self::ALLOWED_TTLS, true)) {
+                $logger->error('Invalid TTL in JSON creation request: ' . json_encode($ttl));
+                return new Response(
+                    Status::BAD_REQUEST,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'ttl must be one of: ' . implode(', ', self::ALLOWED_TTLS)])
+                );
+            }
+
+            if ($maxViews !== null && (!is_int($maxViews) || !in_array($maxViews, self::ALLOWED_MAX_VIEWS, true))) {
+                $logger->error('Invalid max_views in JSON creation request: ' . json_encode($maxViews));
+                return new Response(
+                    Status::BAD_REQUEST,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'max_views must be one of: ' . implode(', ', self::ALLOWED_MAX_VIEWS) . ', or null'])
+                );
+            }
+
+            $result = $service->createJson($encryptedSecret, $verifier, $ttl, $maxViews);
+            $logger->info(sprintf('Created JSON secret %s (ttl=%d, max_views=%s)', $result['id'], $ttl, $maxViews ?? 'unlimited'));
+
+            return new Response(
+                Status::CREATED,
+                ['content-type' => 'application/json'],
+                json_encode($result)
+            );
         });
     }
 

--- a/server/tests/Unit/CreateSecretJsonTest.php
+++ b/server/tests/Unit/CreateSecretJsonTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\SecretService;
+
+class CreateSecretJsonTest extends TestCase
+{
+    private function makeRedisMock(): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['setex', 'get', 'decr', 'del'])
+            ->getMock();
+    }
+
+    // -------------------------------------------------------------------------
+    // createJson() — happy path
+    // -------------------------------------------------------------------------
+
+    public function testCreateJsonReturnsIdExpiresAtAndMaxViews(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('setex')->willReturn(null);
+
+        $service = new SecretService($redis);
+        $result  = $service->createJson('encrypted-payload', 'my-verifier', 86400, 5);
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertArrayHasKey('expires_at', $result);
+        $this->assertArrayHasKey('max_views', $result);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{12}$/', $result['id']);
+        $this->assertSame(5, $result['max_views']);
+    }
+
+    public function testCreateJsonExpiresAtIsIso8601(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('setex')->willReturn(null);
+
+        $service = new SecretService($redis);
+        $result  = $service->createJson('encrypted-payload', 'my-verifier', 3600, null);
+
+        // ISO 8601 / RFC 3339 pattern
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/',
+            $result['expires_at']
+        );
+    }
+
+    public function testCreateJsonExpiresAtReflectsTtl(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('setex')->willReturn(null);
+
+        $before  = time();
+        $service = new SecretService($redis);
+        $result  = $service->createJson('encrypted-payload', 'my-verifier', 3600, null);
+        $after   = time();
+
+        $ts = (new \DateTimeImmutable($result['expires_at']))->getTimestamp();
+        $this->assertGreaterThanOrEqual($before + 3600, $ts);
+        $this->assertLessThanOrEqual($after + 3600, $ts);
+    }
+
+    public function testCreateJsonNullMaxViewsIsPreserved(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('setex')->willReturn(null);
+
+        $service = new SecretService($redis);
+        $result  = $service->createJson('encrypted-payload', 'my-verifier', 86400, null);
+
+        $this->assertNull($result['max_views']);
+    }
+
+    // -------------------------------------------------------------------------
+    // createJson() — Redis key storage
+    // -------------------------------------------------------------------------
+
+    public function testCreateJsonStoresFourKeysWhenMaxViewsSet(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedKeys = [];
+        $redis->expects($this->exactly(4))
+            ->method('setex')
+            ->willReturnCallback(function (string $key) use (&$capturedKeys) {
+                $capturedKeys[] = $key;
+            });
+
+        $service  = new SecretService($redis);
+        $result   = $service->createJson('encrypted-payload', 'my-verifier', 86400, 10);
+        $secretID = $result['id'];
+
+        $this->assertContains("json_verifier:{$secretID}", $capturedKeys);
+        $this->assertContains("json_secret:{$secretID}", $capturedKeys);
+        $this->assertContains("json_expires:{$secretID}", $capturedKeys);
+        $this->assertContains("json_views:{$secretID}", $capturedKeys);
+    }
+
+    public function testCreateJsonStoresThreeKeysWhenMaxViewsNull(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedKeys = [];
+        $redis->expects($this->exactly(3))
+            ->method('setex')
+            ->willReturnCallback(function (string $key) use (&$capturedKeys) {
+                $capturedKeys[] = $key;
+            });
+
+        $service  = new SecretService($redis);
+        $result   = $service->createJson('encrypted-payload', 'my-verifier', 86400, null);
+        $secretID = $result['id'];
+
+        $this->assertContains("json_verifier:{$secretID}", $capturedKeys);
+        $this->assertContains("json_secret:{$secretID}", $capturedKeys);
+        $this->assertContains("json_expires:{$secretID}", $capturedKeys);
+        $this->assertNotContains("json_views:{$secretID}", $capturedKeys);
+    }
+
+    public function testCreateJsonVerifierKeyUsesRequestedTtl(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->method('setex')
+            ->willReturnCallback(function (string $key, int $ttl) use (&$capturedCalls) {
+                $capturedCalls[$key] = $ttl;
+            });
+
+        $service = new SecretService($redis);
+        $result  = $service->createJson('encrypted-payload', 'my-verifier', 3600, 1);
+
+        $secretID = $result['id'];
+        $this->assertSame(3600, $capturedCalls["json_verifier:{$secretID}"]);
+        $this->assertSame(3630, $capturedCalls["json_secret:{$secretID}"]);
+        $this->assertSame(3630, $capturedCalls["json_expires:{$secretID}"]);
+        $this->assertSame(3600, $capturedCalls["json_views:{$secretID}"]);
+    }
+
+    public function testCreateJsonVerifierIsHashedBeforeStorage(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $storedVerifier = null;
+        $redis->method('setex')
+            ->willReturnCallback(function (string $key, int $ttl, string $value) use (&$storedVerifier) {
+                if (str_starts_with($key, 'json_verifier:')) {
+                    $storedVerifier = $value;
+                }
+            });
+
+        $service = new SecretService($redis);
+        $service->createJson('encrypted-payload', 'plain-verifier', 86400, null);
+
+        $this->assertNotNull($storedVerifier);
+        $this->assertNotSame('plain-verifier', $storedVerifier);
+        $this->assertTrue(password_verify('plain-verifier', $storedVerifier));
+    }
+
+    public function testCreateJsonGeneratesUniqueIds(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('setex')->willReturn(null);
+
+        $service = new SecretService($redis);
+        $ids     = [];
+        for ($i = 0; $i < 10; $i++) {
+            $result = $service->createJson('payload', 'verifier', 86400, null);
+            $ids[]  = $result['id'];
+        }
+
+        $this->assertSame(count($ids), count(array_unique($ids)));
+    }
+}

--- a/swagger.yml
+++ b/swagger.yml
@@ -127,27 +127,76 @@ paths:
       tags:
         - "api"
       consumes:
-        - "text/plain"
+        - "application/json"
       produces:
-        - "text/plain"
+        - "application/json"
       parameters:
         - in: "body"
           name: "body"
-          description: |
-            Serialized secret to store in the server. Format: hex(salt)$hex(verifier)$hex(secret)[$ttl]
-            The optional TTL field specifies the secret lifetime in seconds (1–604800). Defaults to 86400.
+          description: "JSON request to store a new encrypted secret."
           required: true
           schema:
-            type: "string"
+            type: "object"
+            required:
+              - "encrypted_secret"
+              - "verifier"
+            properties:
+              encrypted_secret:
+                type: "string"
+                description: "Client-side AES-GCM ciphertext (hex-encoded salt + nonce + ciphertext)"
+              verifier:
+                type: "string"
+                description: "PBKDF2-derived verifier used to authenticate retrieval requests"
+              ttl:
+                type: "integer"
+                description: "Secret lifetime in seconds. Must be one of: 3600, 86400, 604800. Defaults to 86400."
+                default: 86400
+                enum:
+                  - 3600
+                  - 86400
+                  - 604800
+              max_views:
+                type: "integer"
+                description: "Maximum number of times the secret may be retrieved. Must be one of: 1, 5, 10, or omitted/null for unlimited."
+                enum:
+                  - 1
+                  - 5
+                  - 10
       responses:
         "201":
           description: "Created"
+          schema:
+            type: "object"
+            properties:
+              id:
+                type: "string"
+                description: "Secret ID assigned by the server"
+                example: "a1b2c3d4e5f6"
+              expires_at:
+                type: "string"
+                format: "date-time"
+                description: "ISO 8601 timestamp when the secret expires"
+                example: "2024-01-16T12:00:00+00:00"
+              max_views:
+                type: "integer"
+                description: "Maximum retrieval count, or null for unlimited"
+                example: 5
         "400":
-          description: "Bad Request"
+          description: "Bad Request — missing required fields, invalid ttl, or invalid max_views"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "ttl must be one of: 3600, 86400, 604800"
         "413":
           description: "Payload Too Large"
-        "422":
-          description: "Unprocessable Entity — TTL out of range"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Payload Too Large"
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."


### PR DESCRIPTION
## Summary

Implements [DIS-796](https://linear.app/displace-tech/issue/DIS-796/implement-json-requestresponse-format-for-post-apicreate): JSON request/response format for `POST /api/create`.

## Changes

### `server/src/ServerRoutes.php`
- Replaced the legacy text-format `createSecret` handler with a JSON-accepting handler
- Validates `encrypted_secret` (required string) and `verifier` (required string)
- Validates `ttl` against allowed values: `3600`, `86400`, `604800` (defaults to `86400`)
- Validates `max_views` against allowed options: `1`, `5`, `10`, or `null` for unlimited (defaults to `null`)
- Returns `201 Created` with JSON body: `{id, expires_at (ISO 8601), max_views}`
- All error responses return `400 Bad Request` with `{error: "..."}` JSON

### `server/src/SecretService.php`
- Added `createJson()` method that stores secrets under `json_*` Redis keys, compatible with the existing `retrieveJson()` method
- Bcrypt-hashes the verifier before storage
- Stores `json_verifier:`, `json_secret:`, `json_expires:`, and (when bounded) `json_views:` keys
- Returns `id`, `expires_at` (ISO 8601), and `max_views`

### `server/tests/Unit/CreateSecretJsonTest.php`
- New test class covering `SecretService::createJson()`
- Tests: happy path, ISO 8601 format, TTL reflection, null max_views, key storage counts, TTL assignment per key, verifier hashing, and ID uniqueness

### `swagger.yml`
- Updated `/api/create` to document the new JSON request/response contract

## Acceptance Criteria

- [x] `POST /api/create` accepts JSON body
- [x] Validates `encrypted_secret` and `verifier` (required)
- [x] Validates `ttl` against allowed values (3600, 86400, 604800)
- [x] Validates `max_views` against allowed options (1, 5, 10, null)
- [x] Stores secret and returns JSON with `id`, `expires_at` (ISO 8601), `max_views`
- [x] Invalid inputs return `400` with error JSON
- [x] All tests pass