### PR TITLE
DIS-839: No changes needed — liveness/readiness probes already implemented

### DIFF
--- a/FOUNDRY_NOOP.txt
+++ b/FOUNDRY_NOOP.txt
@@ -1,0 +1,12 @@
+Liveness and readiness probes are already implemented in the Helm chart.
+
+- helm/swordfish/templates/deployment.yaml (lines 36-39) renders both
+  livenessProbe and readinessProbe from values.
+- helm/swordfish/values.yaml (lines 31-46) defines httpGet probes on
+  path: /health, port: http with failureThreshold: 3 for both probes.
+
+Running `helm template` confirms the rendered Deployment includes:
+  livenessProbe.httpGet.path: /health
+  readinessProbe.httpGet.path: /health
+
+All acceptance criteria for DIS-839 are already satisfied. No changes needed.


### PR DESCRIPTION
## DIS-839 — Add liveness/readiness probes to Helm chart

Linear: https://linear.app/displace-tech/issue/DIS-839/add-livenessreadiness-probes-to-helm-chart

### Finding

After inspecting the existing Helm chart, the liveness and readiness probes described in DIS-839 are **already fully implemented**:

- `helm/swordfish/templates/deployment.yaml` (lines 36–39) renders both `livenessProbe` and `readinessProbe` from values.
- `helm/swordfish/values.yaml` (lines 31–46) defines `httpGet` probes on `path: /health`, `port: http` with `failureThreshold: 3` for both probes.

`helm template` confirms the rendered Deployment includes:
```yaml
livenessProbe:
  httpGet:
    path: /health
    port: http
  initialDelaySeconds: 30
  periodSeconds: 10
  timeoutSeconds: 5
  failureThreshold: 3
readinessProbe:
  httpGet:
    path: /health
    port: http
  initialDelaySeconds: 5
  periodSeconds: 5
  timeoutSeconds: 5
  failureThreshold: 3
```

### Acceptance Criteria

- ✅ Helm template renders with `httpGet` probes on `/health`
- ✅ Pods restart if health check fails (`failureThreshold: 3`)

No code changes were required. A `FOUNDRY_NOOP.txt` file has been added to document this finding.