### PR TITLE
DIS-843: Implement encryption/decryption module matching v1 crypto

### DIFF
--- a/frontend/src/__tests__/crypto.test.js
+++ b/frontend/src/__tests__/crypto.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { encrypt, decrypt } from '../crypto.js'
+
+const HEX_RE = /^[0-9a-f]+$/
+
+describe('encrypt', () => {
+  it('returns a creation string with three $-delimited segments', async () => {
+    const result = await encrypt('my secret', 'my passphrase')
+    const parts = result.split('$')
+    expect(parts).toHaveLength(3)
+  })
+
+  it('encodes salt as 32 hex chars (16 bytes)', async () => {
+    const [saltHex] = (await encrypt('s', 'p')).split('$')
+    expect(saltHex).toHaveLength(32)
+    expect(HEX_RE.test(saltHex)).toBe(true)
+  })
+
+  it('encodes verifier as 64 hex chars (256 bits)', async () => {
+    const [, verifierHex] = (await encrypt('s', 'p')).split('$')
+    expect(verifierHex).toHaveLength(64)
+    expect(HEX_RE.test(verifierHex)).toBe(true)
+  })
+
+  it('encodes payload starting with 24 hex chars nonce (12 bytes)', async () => {
+    const [, , payload] = (await encrypt('s', 'p')).split('$')
+    const nonceHex = payload.slice(0, 24)
+    expect(nonceHex).toHaveLength(24)
+    expect(HEX_RE.test(nonceHex)).toBe(true)
+  })
+
+  it('produces a different ciphertext on each call (random salt/nonce)', async () => {
+    const a = await encrypt('same secret', 'same passphrase')
+    const b = await encrypt('same secret', 'same passphrase')
+    expect(a).not.toBe(b)
+  })
+
+  it('derives the same verifier for the same passphrase', async () => {
+    const [, verifierA] = (await encrypt('secret1', 'passphrase')).split('$')
+    const [, verifierB] = (await encrypt('secret2', 'passphrase')).split('$')
+    expect(verifierA).toBe(verifierB)
+  })
+
+  it('derives different verifiers for different passphrases', async () => {
+    const [, verifierA] = (await encrypt('secret', 'passphrase1')).split('$')
+    const [, verifierB] = (await encrypt('secret', 'passphrase2')).split('$')
+    expect(verifierA).not.toBe(verifierB)
+  })
+})
+
+describe('decrypt', () => {
+  it('round-trips: decrypt recovers the original secret', async () => {
+    const secret = 'hello, world!'
+    const passphrase = 'correct horse battery staple'
+
+    const creationString = await encrypt(secret, passphrase)
+    const [saltHex, , payload] = creationString.split('$')
+
+    // Server-stored format: hex(salt) + hex(nonce) + hex(ciphertext)
+    const serverPayload = saltHex + payload
+
+    const recovered = await decrypt(serverPayload, passphrase)
+    expect(recovered).toBe(secret)
+  })
+
+  it('round-trips with unicode secrets', async () => {
+    const secret = '🔐 secret café'
+    const passphrase = 'pässwörд'
+
+    const creationString = await encrypt(secret, passphrase)
+    const [saltHex, , payload] = creationString.split('$')
+    const recovered = await decrypt(saltHex + payload, passphrase)
+    expect(recovered).toBe(secret)
+  })
+
+  it('throws when decrypting with the wrong passphrase', async () => {
+    const creationString = await encrypt('secret', 'correct-passphrase')
+    const [saltHex, , payload] = creationString.split('$')
+    await expect(decrypt(saltHex + payload, 'wrong-passphrase')).rejects.toThrow()
+  })
+})

--- a/frontend/src/crypto.js
+++ b/frontend/src/crypto.js
@@ -1,0 +1,103 @@
+/**
+ * Crypto module — AES-256-GCM + PBKDF2 encryption matching v1 wire format.
+ *
+ * Wire formats:
+ *   encrypt() output (creation string):
+ *     hex(salt[16]) + '$' + hex(verifier[32]) + '$' + hex(nonce[12]) + hex(ciphertext)
+ *
+ *   decrypt() input (server-stored payload):
+ *     hex(salt[16]) + hex(nonce[12]) + hex(ciphertext)
+ */
+
+const PEPPER = new TextEncoder().encode('d783eff0523c8fa7336bc768c5950f63')
+
+function encodeBuffer(buffer) {
+  return Array.from(new Uint8Array(buffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function decodeHex(hex) {
+  return new Uint8Array(hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16)))
+}
+
+async function importPassphrase(passphrase) {
+  return globalThis.crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(passphrase),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveBits', 'deriveKey']
+  )
+}
+
+/**
+ * Encrypt a secret with a passphrase.
+ *
+ * @param {string} secret     - Plaintext secret to encrypt
+ * @param {string} passphrase - Passphrase used to derive the encryption key
+ * @returns {Promise<string>} Creation string: hex(salt)$hex(verifier)$hex(nonce)hex(ciphertext)
+ */
+export async function encrypt(secret, passphrase) {
+  const plaintext = new TextEncoder().encode(secret)
+  const salt = globalThis.crypto.getRandomValues(new Uint8Array(16))
+
+  const passkey = await importPassphrase(passphrase)
+
+  const verifier = await globalThis.crypto.subtle.deriveBits(
+    { name: 'PBKDF2', salt: PEPPER, iterations: 10000, hash: 'SHA-256' },
+    passkey,
+    256
+  )
+
+  const derivedKey = await globalThis.crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 10000, hash: 'SHA-256' },
+    passkey,
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt']
+  )
+
+  const nonce = globalThis.crypto.getRandomValues(new Uint8Array(12))
+
+  const ciphertext = await globalThis.crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: nonce },
+    derivedKey,
+    plaintext
+  )
+
+  const payload = encodeBuffer(nonce) + encodeBuffer(ciphertext)
+  return encodeBuffer(salt) + '$' + encodeBuffer(verifier) + '$' + payload
+}
+
+/**
+ * Decrypt a server-stored ciphertext payload with a passphrase.
+ *
+ * @param {string} ciphertext - Server payload: hex(salt[16])hex(nonce[12])hex(encrypted)
+ * @param {string} passphrase - Passphrase used to derive the decryption key
+ * @returns {Promise<string>} The decrypted plaintext secret
+ */
+export async function decrypt(ciphertext, passphrase) {
+  const decoded = decodeHex(ciphertext)
+  const salt = decoded.slice(0, 16)
+  const nonce = decoded.slice(16, 28)
+  const encrypted = decoded.slice(28)
+
+  const passkey = await importPassphrase(passphrase)
+
+  const derivedKey = await globalThis.crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 10000, hash: 'SHA-256' },
+    passkey,
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt']
+  )
+
+  const plaintext = await globalThis.crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: nonce },
+    derivedKey,
+    encrypted
+  )
+
+  return new TextDecoder().decode(plaintext)
+}


### PR DESCRIPTION
## Summary

Ports the v1 Web Crypto API encryption logic into a standalone ES module at `frontend/src/crypto.js`.

Closes / implements [DIS-843](https://linear.app/displace-tech/issue/DIS-843/implement-encryptiondecryption-module-matching-v1-crypto).

## Changes

- **`frontend/src/crypto.js`** — New ES module exporting `encrypt()` and `decrypt()`:
  - `encrypt(secret, passphrase)` → creation string `hex(salt)$hex(verifier)$hex(nonce)hex(ciphertext)`
  - `decrypt(serverPayload, passphrase)` → plaintext string
  - Uses the same pepper (`d783eff0523c8fa7336bc768c5950f63`), PBKDF2 parameters (10 000 iterations, SHA-256), and AES-256-GCM settings as the v1 `create.js`/`retrieve.js` scripts
- **`frontend/src/__tests__/crypto.test.js`** — 10 Vitest tests covering:
  - Creation string format (3 segments, correct byte lengths)
  - Verifier determinism (same passphrase → same verifier; different passphrase → different verifier)
  - Random salt/nonce (two calls with same inputs produce different ciphertext)
  - Round-trip decryption (ASCII and Unicode secrets)
  - Wrong-passphrase rejection

## Acceptance Criteria

- [x] Module exports `encrypt()` and `decrypt()` functions
- [x] Given identical inputs, produces identical ciphertext **format** as v1 (salt/nonce are random per call, so byte values differ, but structure is identical)
- [x] All tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)