### PR TITLE
DIS-838: Switch API to JSON request/response format

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,11 @@
 /**
+ * @typedef {Object} CreateResponse
+ * @property {string} id         - Compound "secretID:verifier" string; split on ':' for the retrieve call
+ * @property {number} expires_at - Unix timestamp when the secret expires
+ * @property {number} max_views  - Maximum number of retrieval views
+ */
+
+/**
  * @typedef {Object} RetrieveResponse
  * @property {string} encrypted_secret - The encrypted secret payload
  * @property {number} views_remaining  - Number of views remaining after this retrieval
@@ -8,30 +15,31 @@
 /**
  * Create a new secret in the datastore.
  *
- * Sends a plain-text payload to POST /api/create in the format:
- *   hex(salt)$hex(verifier)$hex(secret)[$ttl]
+ * Sends a JSON payload to POST /api/create:
+ *   {"encrypted_secret": "...", "ttl": 86400, "max_views": 1}
  *
- * @param {string} payload - Serialized secret string
- * @returns {Promise<string>} The secret ID assigned by the server
+ * The returned `id` is a compound "secretID:verifier" string. Split on ':'
+ * to obtain the secretID and verifier needed for the retrieve endpoint.
+ *
+ * @param {string} encryptedSecret - Client-side encrypted secret payload
+ * @param {number} [ttl=86400]     - Secret lifetime in seconds (1–604800)
+ * @param {number} [maxViews=1]    - Maximum number of retrieval views
+ * @returns {Promise<CreateResponse>} The created secret metadata
  * @throws {Error} On HTTP error or network failure
  */
-export async function createSecret(payload) {
+export async function createSecret(encryptedSecret, ttl = 86400, maxViews = 1) {
   const response = await fetch('/api/create', {
     method: 'POST',
-    headers: { 'Content-Type': 'text/plain' },
-    body: payload,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ encrypted_secret: encryptedSecret, ttl, max_views: maxViews }),
   })
 
   if (!response.ok) {
-    const contentType = response.headers.get('content-type') ?? ''
-    if (contentType.includes('application/json')) {
-      const data = await response.json()
-      throw new Error(data.error ?? response.statusText)
-    }
-    throw new Error(response.statusText)
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.message ?? data.error ?? response.statusText)
   }
 
-  return response.text()
+  return response.json()
 }
 
 /**

--- a/server/server.php
+++ b/server/server.php
@@ -50,7 +50,7 @@ Amp\Loop::run(function () {
     /**  Server back-end API                                  **/
     /***********************************************************/
 
-    $router->addRoute('POST', '/api/create', ServerRoutes::createSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/create', ServerRoutes::createSecretJson($logger, $redisClient));
     $router->addRoute('POST', '/create', ServerRoutes::redirectCreate($logger));
     $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecretJson($logger, $redisClient));
     $router->addRoute('POST', '/retrieve', ServerRoutes::redirectRetrieve($logger));

--- a/server/src/SecretService.php
+++ b/server/src/SecretService.php
@@ -63,6 +63,37 @@ class SecretService
     }
 
     /**
+     * Store a new JSON-API secret in Redis.
+     *
+     * Generates a random 12-character hex ID and a random verifier, stores the
+     * verifier hash, encrypted secret, view counter, and expiry timestamp with
+     * the requested TTL.
+     *
+     * @param string $encryptedSecret Client-side encrypted secret payload
+     * @param int    $ttl             Lifetime in seconds (1–604800)
+     * @param int    $maxViews        Maximum number of retrieval views
+     * @return array{id: string, expires_at: int, max_views: int}
+     *   `id` is a compound "secretID:verifier" string the client must split for retrieval.
+     */
+    public function createJson(string $encryptedSecret, int $ttl, int $maxViews): array
+    {
+        $secretID    = bin2hex(random_bytes(6));
+        $verifier    = bin2hex(random_bytes(16));
+        $expiresAt   = time() + $ttl;
+
+        $this->redis->setex("json_verifier:{$secretID}", $ttl,      password_hash($verifier, PASSWORD_DEFAULT));
+        $this->redis->setex("json_secret:{$secretID}",   $ttl + 30, $encryptedSecret);
+        $this->redis->setex("json_views:{$secretID}",    $ttl,      (string) $maxViews);
+        $this->redis->setex("json_expires:{$secretID}",  $ttl,      (string) $expiresAt);
+
+        return [
+            'id'         => "{$secretID}:{$verifier}",
+            'expires_at' => $expiresAt,
+            'max_views'  => $maxViews,
+        ];
+    }
+
+    /**
      * Retrieve a JSON-API secret after verifying the supplied verifier.
      *
      * Decrements the view counter and deletes all associated keys when views

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -134,6 +134,86 @@ class ServerRoutes
     }
 
     /**
+     * Process a JSON API secret creation request.
+     *
+     * Accepts: {"encrypted_secret": "...", "ttl": 86400, "max_views": 5}
+     * Returns: {"id": "secretID:verifier", "expires_at": T, "max_views": N}
+     *
+     * The returned `id` is a compound "secretID:verifier" string. The client must
+     * split on ":" to obtain the secretID and verifier for the retrieve endpoint.
+     *
+     * @param Logger $logger
+     * @param Client $redisClient
+     * @return CallableRequestHandler
+     */
+    public static function createSecretJson(Logger $logger, Client $redisClient): CallableRequestHandler
+    {
+        $service = new SecretService($redisClient);
+        return new CallableRequestHandler(function(Request $request) use ($logger, $service) {
+            $data = yield $request->getBody()->read();
+
+            if (strlen($data) > 100 * 1000) {
+                $logger->error('JSON create payload too large');
+                return new Response(
+                    Status::PAYLOAD_TOO_LARGE,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Payload Too Large', 'message' => 'Request body exceeds the 100 KB limit.'])
+                );
+            }
+
+            $parsed = json_decode($data, true);
+            if ($parsed === null || !isset($parsed['encrypted_secret'])) {
+                $logger->error('Unable to decode JSON create request');
+                return new Response(
+                    Status::BAD_REQUEST,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Bad Request', 'message' => 'Request body must be valid JSON with an encrypted_secret field.'])
+                );
+            }
+
+            $encryptedSecret = $parsed['encrypted_secret'];
+            $ttl             = isset($parsed['ttl']) ? (int) $parsed['ttl'] : CreateRequest::DEFAULT_TTL;
+            $maxViews        = isset($parsed['max_views']) ? (int) $parsed['max_views'] : 1;
+
+            if ($ttl < 1 || $ttl > CreateRequest::MAX_TTL) {
+                $logger->error(sprintf('Invalid TTL %d in JSON create request', $ttl));
+                return new Response(
+                    Status::UNPROCESSABLE_ENTITY,
+                    ['content-type' => 'application/json'],
+                    json_encode([
+                        'error'   => 'Unprocessable Entity',
+                        'message' => sprintf('ttl must be between 1 and %d seconds.', CreateRequest::MAX_TTL),
+                    ])
+                );
+            }
+
+            if ($maxViews < 1) {
+                $logger->error(sprintf('Invalid max_views %d in JSON create request', $maxViews));
+                return new Response(
+                    Status::UNPROCESSABLE_ENTITY,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Unprocessable Entity', 'message' => 'max_views must be at least 1.'])
+                );
+            }
+
+            try {
+                $result = $service->createJson($encryptedSecret, $ttl, $maxViews);
+            } catch (\Exception $e) {
+                $logger->error('Failed to store JSON secret: ' . $e->getMessage());
+                return new Response(
+                    Status::SERVICE_UNAVAILABLE,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Service Unavailable', 'message' => 'Unable to store secret. Please try again.'])
+                );
+            }
+
+            $logger->info(sprintf('Created JSON secret %s', explode(':', $result['id'])[0]));
+
+            return new Response(Status::CREATED, ['content-type' => 'application/json'], json_encode($result));
+        });
+    }
+
+    /**
      * Check Redis connectivity and return service health status.
      *
      * @param Logger $logger
@@ -224,7 +304,7 @@ class ServerRoutes
                 return new Response(
                     Status::BAD_REQUEST,
                     ['content-type' => 'application/json'],
-                    json_encode(['error' => 'Bad Request'])
+                    json_encode(['error' => 'Bad Request', 'message' => 'Request body must be valid JSON with id and verifier fields.'])
                 );
             }
 
@@ -238,14 +318,14 @@ class ServerRoutes
                 return new Response(
                     Status::UNAUTHORIZED,
                     ['content-type' => 'application/json'],
-                    json_encode(['error' => 'Invalid authorization'])
+                    json_encode(['error' => 'Unauthorized', 'message' => 'Invalid authorization.'])
                 );
             } catch (SecretNotFoundException $e) {
                 $logger->error(sprintf('JSON secret %s was requested but was not found.', $secretID));
                 return new Response(
                     Status::NOT_FOUND,
                     ['content-type' => 'application/json'],
-                    json_encode(['error' => 'Not found or expired'])
+                    json_encode(['error' => 'Not Found', 'message' => 'Secret not found or has expired.'])
                 );
             }
 

--- a/server/tests/Unit/CreateSecretJsonTest.php
+++ b/server/tests/Unit/CreateSecretJsonTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use Amp\Http\Server\Driver\Client;
+use Amp\Http\Server\Request;
+use Amp\Http\Status;
+use League\Uri\Http;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\ServerRoutes;
+
+class CreateSecretJsonTest extends TestCase
+{
+    private function makeRequest(string $body): Request
+    {
+        $client = $this->createMock(Client::class);
+        return new Request($client, 'POST', Http::new('http://localhost/api/create'), [], $body);
+    }
+
+    private function makeRedisMock(): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['setex'])
+            ->getMock();
+    }
+
+    public function testCreateSecretJsonReturns201WithJsonBody(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->exactly(4))->method('setex');
+
+        $handler  = ServerRoutes::createSecretJson($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest(
+            $this->makeRequest(json_encode(['encrypted_secret' => 'enc-payload', 'ttl' => 3600, 'max_views' => 3]))
+        ));
+
+        $this->assertSame(Status::CREATED, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+
+        $this->assertArrayHasKey('id', $parsed);
+        $this->assertArrayHasKey('expires_at', $parsed);
+        $this->assertArrayHasKey('max_views', $parsed);
+        $this->assertSame(3, $parsed['max_views']);
+        $this->assertStringContainsString(':', $parsed['id']);
+    }
+
+    public function testCreateSecretJsonUsesDefaultTtlAndMaxViews(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->exactly(4))->method('setex');
+
+        $handler  = ServerRoutes::createSecretJson($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest(
+            $this->makeRequest(json_encode(['encrypted_secret' => 'enc-payload']))
+        ));
+
+        $this->assertSame(Status::CREATED, $response->getStatus());
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+
+        $this->assertSame(1, $parsed['max_views']);
+        $this->assertGreaterThan(time(), $parsed['expires_at']);
+    }
+
+    public function testCreateSecretJsonReturns400OnInvalidJson(): void
+    {
+        $logger  = new Logger('test');
+        $redis   = $this->makeRedisMock();
+        $handler = ServerRoutes::createSecretJson($logger, $redis);
+
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest('not-json')));
+
+        $this->assertSame(Status::BAD_REQUEST, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertArrayHasKey('error', $parsed);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+
+    public function testCreateSecretJsonReturns400WhenEncryptedSecretMissing(): void
+    {
+        $logger  = new Logger('test');
+        $redis   = $this->makeRedisMock();
+        $handler = ServerRoutes::createSecretJson($logger, $redis);
+
+        $response = \Amp\Promise\wait($handler->handleRequest(
+            $this->makeRequest(json_encode(['ttl' => 3600]))
+        ));
+
+        $this->assertSame(Status::BAD_REQUEST, $response->getStatus());
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertArrayHasKey('error', $parsed);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+
+    public function testCreateSecretJsonReturns422OnTtlTooLow(): void
+    {
+        $logger  = new Logger('test');
+        $redis   = $this->makeRedisMock();
+        $handler = ServerRoutes::createSecretJson($logger, $redis);
+
+        $response = \Amp\Promise\wait($handler->handleRequest(
+            $this->makeRequest(json_encode(['encrypted_secret' => 'enc', 'ttl' => 0]))
+        ));
+
+        $this->assertSame(Status::UNPROCESSABLE_ENTITY, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertArrayHasKey('error', $parsed);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+
+    public function testCreateSecretJsonReturns422OnTtlTooHigh(): void
+    {
+        $logger  = new Logger('test');
+        $redis   = $this->makeRedisMock();
+        $handler = ServerRoutes::createSecretJson($logger, $redis);
+
+        $response = \Amp\Promise\wait($handler->handleRequest(
+            $this->makeRequest(json_encode(['encrypted_secret' => 'enc', 'ttl' => 999999]))
+        ));
+
+        $this->assertSame(Status::UNPROCESSABLE_ENTITY, $response->getStatus());
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertArrayHasKey('error', $parsed);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+
+    public function testCreateSecretJsonReturns422OnMaxViewsLessThanOne(): void
+    {
+        $logger  = new Logger('test');
+        $redis   = $this->makeRedisMock();
+        $handler = ServerRoutes::createSecretJson($logger, $redis);
+
+        $response = \Amp\Promise\wait($handler->handleRequest(
+            $this->makeRequest(json_encode(['encrypted_secret' => 'enc', 'max_views' => 0]))
+        ));
+
+        $this->assertSame(Status::UNPROCESSABLE_ENTITY, $response->getStatus());
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertArrayHasKey('error', $parsed);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+
+    public function testCreateSecretJsonReturns413OnOversizedPayload(): void
+    {
+        $logger  = new Logger('test');
+        $redis   = $this->makeRedisMock();
+        $handler = ServerRoutes::createSecretJson($logger, $redis);
+
+        $oversized = str_repeat('x', 101 * 1000);
+        $response  = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($oversized)));
+
+        $this->assertSame(Status::PAYLOAD_TOO_LARGE, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertArrayHasKey('error', $parsed);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+}

--- a/server/tests/Unit/SecretServiceTest.php
+++ b/server/tests/Unit/SecretServiceTest.php
@@ -87,6 +87,89 @@ class SecretServiceTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // createJson()
+    // -------------------------------------------------------------------------
+
+    public function testCreateJsonStoresFourKeysInRedis(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $redis->expects($this->exactly(4))
+            ->method('setex')
+            ->willReturnCallback(function (string $key, int $ttl, string $value) {
+                $this->assertGreaterThan(0, $ttl);
+                $this->assertNotEmpty($value);
+            });
+
+        $service = new SecretService($redis);
+        $result  = $service->createJson('encrypted-payload', 3600, 5);
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertArrayHasKey('expires_at', $result);
+        $this->assertArrayHasKey('max_views', $result);
+        $this->assertSame(5, $result['max_views']);
+        $this->assertStringContainsString(':', $result['id']);
+    }
+
+    public function testCreateJsonIdContainsSecretIdAndVerifier(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('setex');
+
+        $service = new SecretService($redis);
+        $result  = $service->createJson('encrypted-payload', 3600, 1);
+
+        [$secretID, $verifier] = explode(':', $result['id'], 2);
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{12}$/', $secretID);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $verifier);
+    }
+
+    public function testCreateJsonExpiresAtIsApproximatelyNowPlusTtl(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('setex');
+
+        $service   = new SecretService($redis);
+        $ttl       = 7200;
+        $before    = time();
+        $result    = $service->createJson('encrypted-payload', $ttl, 1);
+        $after     = time();
+
+        $this->assertGreaterThanOrEqual($before + $ttl, $result['expires_at']);
+        $this->assertLessThanOrEqual($after + $ttl, $result['expires_at']);
+    }
+
+    public function testCreateJsonUsesCorrectTtlsForRedisKeys(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->expects($this->exactly(4))
+            ->method('setex')
+            ->willReturnCallback(function (string $key, int $ttl, string $value) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'ttl' => $ttl];
+            });
+
+        $service = new SecretService($redis);
+        $service->createJson('encrypted-payload', 3600, 2);
+
+        $byPrefix = [];
+        foreach ($capturedCalls as $call) {
+            foreach (['json_verifier', 'json_secret', 'json_views', 'json_expires'] as $prefix) {
+                if (str_starts_with($call['key'], $prefix . ':')) {
+                    $byPrefix[$prefix] = $call['ttl'];
+                }
+            }
+        }
+
+        $this->assertSame(3600, $byPrefix['json_verifier']);
+        $this->assertSame(3630, $byPrefix['json_secret']);
+        $this->assertSame(3600, $byPrefix['json_views']);
+        $this->assertSame(3600, $byPrefix['json_expires']);
+    }
+
+    // -------------------------------------------------------------------------
     // retrieve()
     // -------------------------------------------------------------------------
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -127,27 +127,78 @@ paths:
       tags:
         - "api"
       consumes:
-        - "text/plain"
+        - "application/json"
       produces:
-        - "text/plain"
+        - "application/json"
       parameters:
         - in: "body"
           name: "body"
-          description: |
-            Serialized secret to store in the server. Format: hex(salt)$hex(verifier)$hex(secret)[$ttl]
-            The optional TTL field specifies the secret lifetime in seconds (1–604800). Defaults to 86400.
+          description: "JSON secret creation request."
           required: true
           schema:
-            type: "string"
+            type: "object"
+            required:
+              - "encrypted_secret"
+            properties:
+              encrypted_secret:
+                type: "string"
+                description: "Client-side encrypted secret payload"
+              ttl:
+                type: "integer"
+                description: "Secret lifetime in seconds (1–604800). Defaults to 86400."
+                default: 86400
+              max_views:
+                type: "integer"
+                description: "Maximum number of retrieval views. Defaults to 1."
+                default: 1
       responses:
         "201":
           description: "Created"
+          schema:
+            type: "object"
+            properties:
+              id:
+                type: "string"
+                description: "Compound secretID:verifier string. Split on ':' to obtain the id and verifier for the retrieve endpoint."
+              expires_at:
+                type: "integer"
+                description: "Unix timestamp when the secret expires"
+              max_views:
+                type: "integer"
+                description: "Maximum number of retrieval views"
         "400":
           description: "Bad Request"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Bad Request"
+              message:
+                type: "string"
+                example: "Request body must be valid JSON with an encrypted_secret field."
         "413":
           description: "Payload Too Large"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Payload Too Large"
+              message:
+                type: "string"
+                example: "Request body exceeds the 100 KB limit."
         "422":
-          description: "Unprocessable Entity — TTL out of range"
+          description: "Unprocessable Entity — TTL out of range or max_views < 1"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Unprocessable Entity"
+              message:
+                type: "string"
+                example: "ttl must be between 1 and 604800 seconds."
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."
@@ -197,6 +248,9 @@ paths:
               error:
                 type: "string"
                 example: "Bad Request"
+              message:
+                type: "string"
+                example: "Request body must be valid JSON with id and verifier fields."
         "401":
           description: "Unauthorized"
           schema:
@@ -204,7 +258,10 @@ paths:
             properties:
               error:
                 type: "string"
-                example: "Invalid authorization"
+                example: "Unauthorized"
+              message:
+                type: "string"
+                example: "Invalid authorization."
         "404":
           description: "Not Found"
           schema:
@@ -212,4 +269,7 @@ paths:
             properties:
               error:
                 type: "string"
-                example: "Not found or expired"
+                example: "Not Found"
+              message:
+                type: "string"
+                example: "Secret not found or has expired."


### PR DESCRIPTION
## DIS-838: Switch API to JSON request/response format

Linear: https://linear.app/displace-tech/issue/DIS-838/switch-api-to-json-requestresponse-format

### Changes

**`POST /api/create`** — now accepts and returns JSON:
- Input: `{"encrypted_secret": "...", "ttl": 86400, "max_views": 1}`
- Output: `{"id": "secretID:verifier", "expires_at": T, "max_views": N}`
- The `id` field is a compound `secretID:verifier` string; callers split on `:` to obtain the `id` and `verifier` needed for the retrieve endpoint
- All error responses include both `error` and `message` fields
- Content-Type: `application/json`

**`POST /api/retrieve`** — already JSON; error responses updated:
- All error responses now include both `error` and `message` fields

### Implementation

- `SecretService::createJson()` — generates a server-side verifier, stores `json_verifier`, `json_secret`, `json_views`, and `json_expires` keys in Redis
- `ServerRoutes::createSecretJson()` — new handler wired to `POST /api/create`
- `frontend/src/api.js` — `createSecret()` updated to send JSON and return `CreateResponse`
- `swagger.yml` — `/api/create` spec updated to JSON format; `/api/retrieve` error schemas updated

### Tests

- Added `CreateSecretJsonTest` (8 handler tests covering success, validation errors, and oversized payload)
- Added 4 `SecretService::createJson()` unit tests
- All 36 tests pass