### PR TITLE
DIS-851: Add PHPUnit and JS test steps to CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,36 @@ jobs:
 
       - name: Run PHPUnit tests
         working-directory: server
-        run: vendor/bin/phpunit
+        run: composer test
         env:
           REDIS_HOST: 127.0.0.1
           REDIS_PORT: 6379
 
+  js-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run Vitest tests
+        working-directory: frontend
+        run: npm test
+
   build:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, js-test]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

Adds both PHP and JavaScript test steps to the CI pipeline as required by [DIS-851](https://linear.app/displace-tech/issue/DIS-851/add-phpunit-and-js-test-steps-to-ci-pipeline).

## Changes

- **`test` job**: Updated to run `composer test` (PHPUnit) instead of invoking `vendor/bin/phpunit` directly, matching the script defined in `server/composer.json`.
- **`js-test` job** (new): Runs `npm test` (Vitest) against the frontend test suite. Runs in parallel with the `test` job.
- **`build` job**: Now gates on both `test` and `js-test` passing (`needs: [test, js-test]`), so the Docker image is only built and pushed when all tests pass.

## Acceptance Criteria

- [x] CI runs both PHP (`composer test`) and JS (`npm test`) tests
- [x] Pipeline fails if any test fails
- [x] Test results are visible in Actions output