### PR TITLE
DIS-847: Implement configurable expiration (TTL)

### DIFF
--- a/server/src/CreateRequest.php
+++ b/server/src/CreateRequest.php
@@ -5,7 +5,7 @@ namespace Swordfish\Server;
 class CreateRequest
 {
     const DEFAULT_TTL = 86400;
-    const MAX_TTL = 604800;
+    const ALLOWED_TTLS = [3600, 21600, 86400, 259200, 604800];
 
     protected string $salt;
     protected string $verifier;
@@ -82,8 +82,8 @@ class CreateRequest
        $ttl = self::DEFAULT_TTL;
        if (sizeof($parts) === 4) {
            $ttl = (int) $parts[3];
-           if ($ttl < 1 || $ttl > self::MAX_TTL) {
-               throw new \InvalidArgumentException(sprintf('TTL must be between 1 and %d seconds.', self::MAX_TTL));
+           if (!in_array($ttl, self::ALLOWED_TTLS, true)) {
+               throw new \InvalidArgumentException(sprintf('TTL must be one of: %s seconds.', implode(', ', self::ALLOWED_TTLS)));
            }
        }
 

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -120,7 +120,7 @@ class ServerRoutes
                 $secretRequest = CreateRequest::fromString($data);
             } catch (\InvalidArgumentException $e) {
                 $logger->error('Invalid TTL in creation request: ' . $e->getMessage());
-                return new Response(Status::UNPROCESSABLE_ENTITY, ['content-type' => 'application/json'], json_encode(['error' => $e->getMessage()]));
+                return new Response(Status::BAD_REQUEST, ['content-type' => 'application/json'], json_encode(['error' => $e->getMessage()]));
             } catch (\Exception $e) {
                 $logger->error('Unable to decode creation request');
                 return new Response(Status::BAD_REQUEST, ['content-type' => 'text/plain'], 'Bad Request');

--- a/server/tests/Unit/CreateRequestTest.php
+++ b/server/tests/Unit/CreateRequestTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Swordfish\Server\CreateRequest;
+
+class CreateRequestTest extends TestCase
+{
+    private string $salt;
+    private string $verifier;
+    private string $secret;
+    private string $hexSalt;
+    private string $hexVerifier;
+    private string $hexSecret;
+
+    protected function setUp(): void
+    {
+        $this->salt     = str_repeat('a', 16);
+        $this->verifier = str_repeat('b', 32);
+        $this->secret   = 'my-secret-payload';
+
+        $this->hexSalt     = bin2hex($this->salt);
+        $this->hexVerifier = bin2hex($this->verifier);
+        $this->hexSecret   = bin2hex($this->secret);
+    }
+
+    // -------------------------------------------------------------------------
+    // fromString() — default TTL
+    // -------------------------------------------------------------------------
+
+    public function testFromStringUsesDefaultTtlWhenOmitted(): void
+    {
+        $raw     = implode('$', [$this->hexSalt, $this->hexVerifier, $this->hexSecret]);
+        $request = CreateRequest::fromString($raw);
+
+        $this->assertSame(CreateRequest::DEFAULT_TTL, $request->ttl());
+    }
+
+    // -------------------------------------------------------------------------
+    // fromString() — valid TTL values
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dataProvider allowedTtlProvider
+     */
+    public function testFromStringAcceptsAllowedTtlValues(int $ttl): void
+    {
+        $raw     = implode('$', [$this->hexSalt, $this->hexVerifier, $this->hexSecret, (string) $ttl]);
+        $request = CreateRequest::fromString($raw);
+
+        $this->assertSame($ttl, $request->ttl());
+    }
+
+    public static function allowedTtlProvider(): array
+    {
+        return array_map(fn(int $ttl) => [$ttl], CreateRequest::ALLOWED_TTLS);
+    }
+
+    // -------------------------------------------------------------------------
+    // fromString() — invalid TTL values
+    // -------------------------------------------------------------------------
+
+    /**
+     * @dataProvider disallowedTtlProvider
+     */
+    public function testFromStringRejectsDisallowedTtlValues(int $ttl): void
+    {
+        $raw = implode('$', [$this->hexSalt, $this->hexVerifier, $this->hexSecret, (string) $ttl]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        CreateRequest::fromString($raw);
+    }
+
+    public static function disallowedTtlProvider(): array
+    {
+        return [
+            'zero'          => [0],
+            'negative'      => [-1],
+            'one second'    => [1],
+            'arbitrary'     => [1000],
+            'just under 1h' => [3599],
+            'between 1h-6h' => [7200],
+            'over max'      => [604801],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // fromString() — structural validation
+    // -------------------------------------------------------------------------
+
+    public function testFromStringThrowsOnTooFewParts(): void
+    {
+        $this->expectException(\Exception::class);
+        CreateRequest::fromString($this->hexSalt . '$' . $this->hexVerifier);
+    }
+
+    public function testFromStringThrowsOnTooManyParts(): void
+    {
+        $raw = implode('$', [$this->hexSalt, $this->hexVerifier, $this->hexSecret, '86400', 'extra']);
+
+        $this->expectException(\Exception::class);
+        CreateRequest::fromString($raw);
+    }
+
+    public function testFromStringThrowsOnInvalidSaltLength(): void
+    {
+        $shortSalt = bin2hex(str_repeat('x', 8)); // 8 bytes instead of 16
+
+        $this->expectException(\Exception::class);
+        CreateRequest::fromString(implode('$', [$shortSalt, $this->hexVerifier, $this->hexSecret]));
+    }
+
+    public function testFromStringThrowsOnInvalidVerifierLength(): void
+    {
+        $shortVerifier = bin2hex(str_repeat('y', 16)); // 16 bytes instead of 32
+
+        $this->expectException(\Exception::class);
+        CreateRequest::fromString(implode('$', [$this->hexSalt, $shortVerifier, $this->hexSecret]));
+    }
+}

--- a/swagger.yml
+++ b/swagger.yml
@@ -143,11 +143,9 @@ paths:
         "201":
           description: "Created"
         "400":
-          description: "Bad Request"
+          description: "Bad Request — malformed payload or invalid TTL (must be one of: 3600, 21600, 86400, 259200, 604800)"
         "413":
           description: "Payload Too Large"
-        "422":
-          description: "Unprocessable Entity — TTL out of range"
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."


### PR DESCRIPTION
## DIS-847: Implement configurable expiration (TTL)

Linear: https://linear.app/displace-tech/issue/DIS-847/implement-configurable-expiration-ttl

### Changes

- **`CreateRequest`**: Replaced `MAX_TTL` range check with `ALLOWED_TTLS` constant `[3600, 21600, 86400, 259200, 604800]`; `fromString()` now validates the TTL field against this list and throws `\InvalidArgumentException` for any value not in it. Default remains `86400`.
- **`ServerRoutes`**: Changed the invalid-TTL response from `422 Unprocessable Entity` to `400 Bad Request` per the acceptance criteria.
- **`swagger.yml`**: Removed the `422` response from `POST /api/create`; updated the `400` description to document TTL validation.
- **`CreateRequestTest`**: New unit test class covering all five allowed TTL values, seven disallowed values, default TTL when omitted, and structural validation (too few/many parts, bad salt/verifier length).

### Acceptance Criteria

- [x] Secrets respect the TTL passed at creation (1h/6h/24h/3d/7d)
- [x] Invalid TTLs are rejected with a 400 error
- [x] Default is 24h (86400 s)