### PR TITLE
DIS-848: Implement internal usage metrics collection

### DIFF
--- a/server/server.php
+++ b/server/server.php
@@ -14,6 +14,7 @@ use Amp\Log\ConsoleFormatter;
 use Amp\Log\StreamHandler;
 use Amp\Socket;
 use Monolog\Logger;
+use Swordfish\Server\MetricsService;
 use Swordfish\Server\ServerRoutes;
 
 Amp\Loop::run(function () {
@@ -34,6 +35,8 @@ Amp\Loop::run(function () {
         'port'   => getenv('REDIS_PORT')
     ]);
 
+    $metrics = new MetricsService($redisClient);
+
     $documentRoot = new DocumentRoot(__DIR__ . '/static');
     $router = new Router();
 
@@ -50,10 +53,11 @@ Amp\Loop::run(function () {
     /**  Server back-end API                                  **/
     /***********************************************************/
 
-    $router->addRoute('POST', '/api/create', ServerRoutes::createSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/create', ServerRoutes::createSecret($logger, $redisClient, $metrics));
     $router->addRoute('POST', '/create', ServerRoutes::redirectCreate($logger));
-    $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecretJson($logger, $redisClient));
+    $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecretJson($logger, $redisClient, $metrics));
     $router->addRoute('POST', '/retrieve', ServerRoutes::redirectRetrieve($logger));
+    $router->addRoute('GET', '/api/metrics', ServerRoutes::metricsEndpoint($logger, $metrics));
 
     $router->setFallback(ServerRoutes::spaFallback($logger, $documentRoot));
 

--- a/server/src/MetricsService.php
+++ b/server/src/MetricsService.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Swordfish\Server;
+
+use Predis\Client;
+
+class MetricsService
+{
+    public function __construct(private Client $redis) {}
+
+    /**
+     * Record a secret creation event.
+     *
+     * Increments the hourly created count and bytes-stored counter for today.
+     *
+     * @param int $bytes Number of bytes stored
+     */
+    public function recordCreated(int $bytes): void
+    {
+        $date = date('Y-m-d');
+        $hour = date('H');
+        $this->redis->hincrby("metrics:created:{$date}", $hour, 1);
+        $this->redis->hincrby("metrics:bytes_stored:{$date}", $hour, $bytes);
+    }
+
+    /**
+     * Record a successful secret retrieval event.
+     *
+     * Increments the hourly retrieved count and bytes-retrieved counter for today.
+     *
+     * @param int $bytes Number of bytes retrieved
+     */
+    public function recordRetrieved(int $bytes): void
+    {
+        $date = date('Y-m-d');
+        $hour = date('H');
+        $this->redis->hincrby("metrics:retrieved:{$date}", $hour, 1);
+        $this->redis->hincrby("metrics:bytes_retrieved:{$date}", $hour, $bytes);
+    }
+
+    /**
+     * Record a secret-expired-without-retrieval event (lazy detection).
+     *
+     * Called when a retrieval attempt finds no secret in Redis, indicating
+     * the secret expired before it was retrieved.
+     */
+    public function recordExpired(): void
+    {
+        $date = date('Y-m-d');
+        $hour = date('H');
+        $this->redis->hincrby("metrics:expired:{$date}", $hour, 1);
+    }
+
+    /**
+     * Return all metric counters for the given date.
+     *
+     * Each counter is a hash keyed by two-digit hour (00–23).
+     *
+     * @param string $date Date in YYYY-MM-DD format; defaults to today
+     * @return array{created: array, bytes_stored: array, retrieved: array, bytes_retrieved: array, expired: array}
+     */
+    public function getMetrics(string $date = ''): array
+    {
+        if ($date === '') {
+            $date = date('Y-m-d');
+        }
+
+        return [
+            'created'        => $this->redis->hgetall("metrics:created:{$date}") ?: [],
+            'bytes_stored'   => $this->redis->hgetall("metrics:bytes_stored:{$date}") ?: [],
+            'retrieved'      => $this->redis->hgetall("metrics:retrieved:{$date}") ?: [],
+            'bytes_retrieved' => $this->redis->hgetall("metrics:bytes_retrieved:{$date}") ?: [],
+            'expired'        => $this->redis->hgetall("metrics:expired:{$date}") ?: [],
+        ];
+    }
+}

--- a/server/src/SecretService.php
+++ b/server/src/SecretService.php
@@ -6,7 +6,7 @@ use Predis\Client;
 
 class SecretService
 {
-    public function __construct(private Client $redis) {}
+    public function __construct(private Client $redis, private ?MetricsService $metrics = null) {}
 
     /**
      * Store a new secret and its verifier hash in Redis.
@@ -24,8 +24,11 @@ class SecretService
         $verifierKey = "verifier:{$secretID}";
         $ttl         = $request->ttl();
 
+        $secret = $request->secret();
         $this->redis->setex($verifierKey, $ttl, $request->verifier());
-        $this->redis->setex($secretKey, $ttl + 30, $request->secret());
+        $this->redis->setex($secretKey, $ttl + 30, $secret);
+
+        $this->metrics?->recordCreated(strlen($secret));
 
         return $secretID;
     }
@@ -47,6 +50,7 @@ class SecretService
 
         $hash = $this->redis->get($verifierKey);
         if ($hash === null) {
+            $this->metrics?->recordExpired();
             throw new SecretNotFoundException(sprintf('Verification code for secret %s not found.', $secretID));
         }
 
@@ -56,8 +60,11 @@ class SecretService
 
         $secret = $this->redis->get($secretKey);
         if ($secret === null) {
+            $this->metrics?->recordExpired();
             throw new SecretNotFoundException(sprintf('Secret %s not found.', $secretID));
         }
+
+        $this->metrics?->recordRetrieved(strlen($secret));
 
         return $secret;
     }
@@ -84,6 +91,7 @@ class SecretService
 
         $hash = $this->redis->get($verifierKey);
         if ($hash === null) {
+            $this->metrics?->recordExpired();
             throw new SecretNotFoundException(sprintf('Verification code for JSON secret %s not found.', $secretID));
         }
 
@@ -93,6 +101,7 @@ class SecretService
 
         $encryptedSecret = $this->redis->get($secretKey);
         if ($encryptedSecret === null) {
+            $this->metrics?->recordExpired();
             throw new SecretNotFoundException(sprintf('JSON secret %s not found.', $secretID));
         }
 
@@ -102,6 +111,8 @@ class SecretService
         if ($viewsAfter <= 0) {
             $this->redis->del($secretKey, $verifierKey, $viewsKey, $expiresKey);
         }
+
+        $this->metrics?->recordRetrieved(strlen($encryptedSecret));
 
         return [
             'encrypted_secret' => $encryptedSecret,

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -104,11 +104,12 @@ class ServerRoutes
      *
      * @param Logger $logger
      * @param Client $redisClient
+     * @param MetricsService $metrics
      * @return CallableRequestHandler
      */
-    public static function createSecret(Logger $logger, Client $redisClient): CallableRequestHandler
+    public static function createSecret(Logger $logger, Client $redisClient, MetricsService $metrics): CallableRequestHandler
     {
-        $service = new SecretService($redisClient);
+        $service = new SecretService($redisClient, $metrics);
         return new CallableRequestHandler(function(Request $request) use ($logger, $service) {
             $data = yield $request->getBody()->read();
             if (strlen($data) > 100 * 1000) {
@@ -167,11 +168,12 @@ class ServerRoutes
      *
      * @param Logger $logger
      * @param Client $redisClient
+     * @param MetricsService $metrics
      * @return CallableRequestHandler
      */
-    public static function retrieveSecret(Logger $logger, Client $redisClient): CallableRequestHandler
+    public static function retrieveSecret(Logger $logger, Client $redisClient, MetricsService $metrics): CallableRequestHandler
     {
-        $service = new SecretService($redisClient);
+        $service = new SecretService($redisClient, $metrics);
         return new CallableRequestHandler(function (Request $request) use ($logger, $service) {
             $data = yield $request->getBody()->read();
 
@@ -210,11 +212,12 @@ class ServerRoutes
      *
      * @param Logger $logger
      * @param Client $redisClient
+     * @param MetricsService $metrics
      * @return CallableRequestHandler
      */
-    public static function retrieveSecretJson(Logger $logger, Client $redisClient): CallableRequestHandler
+    public static function retrieveSecretJson(Logger $logger, Client $redisClient, MetricsService $metrics): CallableRequestHandler
     {
-        $service = new SecretService($redisClient);
+        $service = new SecretService($redisClient, $metrics);
         return new CallableRequestHandler(function (Request $request) use ($logger, $service) {
             $data = yield $request->getBody()->read();
 
@@ -259,6 +262,42 @@ class ServerRoutes
                 Status::OK,
                 ['content-type' => 'application/json'],
                 json_encode($result)
+            );
+        });
+    }
+
+    /**
+     * Return usage metric counters for a given date (defaults to today).
+     *
+     * Accepts an optional `date` query parameter in YYYY-MM-DD format.
+     * Returns hourly hash counters for created, bytes_stored, retrieved,
+     * bytes_retrieved, and expired events.
+     *
+     * @param Logger $logger
+     * @param MetricsService $metrics
+     * @return CallableRequestHandler
+     */
+    public static function metricsEndpoint(Logger $logger, MetricsService $metrics): CallableRequestHandler
+    {
+        return new CallableRequestHandler(function (Request $request) use ($logger, $metrics): Response {
+            $query = $request->getUri()->getQuery();
+            parse_str($query, $params);
+            $date = $params['date'] ?? '';
+
+            if ($date !== '' && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+                return new Response(
+                    Status::UNPROCESSABLE_ENTITY,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Invalid date format; expected YYYY-MM-DD'])
+                );
+            }
+
+            $logger->info(sprintf('Metrics requested for date: %s', $date ?: date('Y-m-d')));
+
+            return new Response(
+                Status::OK,
+                ['content-type' => 'application/json'],
+                json_encode($metrics->getMetrics($date))
             );
         });
     }

--- a/server/tests/Unit/MetricsServiceTest.php
+++ b/server/tests/Unit/MetricsServiceTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\MetricsService;
+
+class MetricsServiceTest extends TestCase
+{
+    private function makeRedisMock(): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['hincrby', 'hgetall'])
+            ->getMock();
+    }
+
+    // -------------------------------------------------------------------------
+    // recordCreated()
+    // -------------------------------------------------------------------------
+
+    public function testRecordCreatedIncrementsCreatedAndBytesStoredCounters(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->expects($this->exactly(2))
+            ->method('hincrby')
+            ->willReturnCallback(function (string $key, string $field, int $value) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'field' => $field, 'value' => $value];
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordCreated(512);
+
+        $createdCall    = array_filter($capturedCalls, fn($c) => str_starts_with($c['key'], 'metrics:created:'));
+        $bytesCall      = array_filter($capturedCalls, fn($c) => str_starts_with($c['key'], 'metrics:bytes_stored:'));
+
+        $this->assertCount(1, $createdCall);
+        $this->assertCount(1, $bytesCall);
+
+        $this->assertSame(1, array_values($createdCall)[0]['value']);
+        $this->assertSame(512, array_values($bytesCall)[0]['value']);
+    }
+
+    public function testRecordCreatedUsesTodaysDateInKey(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedKeys = [];
+        $redis->method('hincrby')
+            ->willReturnCallback(function (string $key) use (&$capturedKeys) {
+                $capturedKeys[] = $key;
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordCreated(100);
+
+        $today = date('Y-m-d');
+        foreach ($capturedKeys as $key) {
+            $this->assertStringContainsString($today, $key);
+        }
+    }
+
+    public function testRecordCreatedUsesCurrentHourAsField(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedFields = [];
+        $redis->method('hincrby')
+            ->willReturnCallback(function (string $key, string $field) use (&$capturedFields) {
+                $capturedFields[] = $field;
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordCreated(100);
+
+        $hour = date('H');
+        foreach ($capturedFields as $field) {
+            $this->assertSame($hour, $field);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // recordRetrieved()
+    // -------------------------------------------------------------------------
+
+    public function testRecordRetrievedIncrementsRetrievedAndBytesRetrievedCounters(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->expects($this->exactly(2))
+            ->method('hincrby')
+            ->willReturnCallback(function (string $key, string $field, int $value) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'value' => $value];
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordRetrieved(256);
+
+        $retrievedCall  = array_filter($capturedCalls, fn($c) => str_starts_with($c['key'], 'metrics:retrieved:'));
+        $bytesCall      = array_filter($capturedCalls, fn($c) => str_starts_with($c['key'], 'metrics:bytes_retrieved:'));
+
+        $this->assertCount(1, $retrievedCall);
+        $this->assertCount(1, $bytesCall);
+
+        $this->assertSame(1, array_values($retrievedCall)[0]['value']);
+        $this->assertSame(256, array_values($bytesCall)[0]['value']);
+    }
+
+    // -------------------------------------------------------------------------
+    // recordExpired()
+    // -------------------------------------------------------------------------
+
+    public function testRecordExpiredIncrementsExpiredCounter(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->expects($this->once())
+            ->method('hincrby')
+            ->willReturnCallback(function (string $key, string $field, int $value) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'value' => $value];
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordExpired();
+
+        $this->assertCount(1, $capturedCalls);
+        $this->assertStringStartsWith('metrics:expired:', $capturedCalls[0]['key']);
+        $this->assertSame(1, $capturedCalls[0]['value']);
+    }
+
+    // -------------------------------------------------------------------------
+    // getMetrics()
+    // -------------------------------------------------------------------------
+
+    public function testGetMetricsReturnsAllCountersForGivenDate(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $redis->method('hgetall')
+            ->willReturnCallback(function (string $key) {
+                if (str_starts_with($key, 'metrics:created:')) {
+                    return ['09' => '5'];
+                }
+                if (str_starts_with($key, 'metrics:bytes_stored:')) {
+                    return ['09' => '2048'];
+                }
+                if (str_starts_with($key, 'metrics:retrieved:')) {
+                    return ['09' => '3'];
+                }
+                if (str_starts_with($key, 'metrics:bytes_retrieved:')) {
+                    return ['09' => '1024'];
+                }
+                if (str_starts_with($key, 'metrics:expired:')) {
+                    return ['09' => '1'];
+                }
+                return [];
+            });
+
+        $service = new MetricsService($redis);
+        $result  = $service->getMetrics('2025-01-15');
+
+        $this->assertSame(['09' => '5'], $result['created']);
+        $this->assertSame(['09' => '2048'], $result['bytes_stored']);
+        $this->assertSame(['09' => '3'], $result['retrieved']);
+        $this->assertSame(['09' => '1024'], $result['bytes_retrieved']);
+        $this->assertSame(['09' => '1'], $result['expired']);
+    }
+
+    public function testGetMetricsDefaultsToTodayWhenNoDateGiven(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedKeys = [];
+        $redis->method('hgetall')
+            ->willReturnCallback(function (string $key) use (&$capturedKeys) {
+                $capturedKeys[] = $key;
+                return [];
+            });
+
+        $service = new MetricsService($redis);
+        $service->getMetrics();
+
+        $today = date('Y-m-d');
+        foreach ($capturedKeys as $key) {
+            $this->assertStringContainsString($today, $key);
+        }
+    }
+
+    public function testGetMetricsReturnsEmptyArraysWhenNoDataExists(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('hgetall')->willReturn(null);
+
+        $service = new MetricsService($redis);
+        $result  = $service->getMetrics('2025-01-01');
+
+        $this->assertSame([], $result['created']);
+        $this->assertSame([], $result['bytes_stored']);
+        $this->assertSame([], $result['retrieved']);
+        $this->assertSame([], $result['bytes_retrieved']);
+        $this->assertSame([], $result['expired']);
+    }
+}


### PR DESCRIPTION
## Summary

Implements internal usage metrics collection as described in [DIS-848](https://linear.app/displace-tech/issue/DIS-848/implement-internal-usage-metrics-collection).

## Changes

### New: `MetricsService`
- Tracks secrets created, retrieved, bytes stored/retrieved, and expired-without-retrieval in Redis
- Uses `HINCRBY` with hourly granularity under date-keyed hashes (e.g. `metrics:created:YYYY-MM-DD`, field `HH`)
- `getMetrics(date)` returns all five counter hashes for a given date (defaults to today)

### Updated: `SecretService`
- Accepts an optional `MetricsService` (null-safe `?->` calls, backward-compatible)
- `create()` calls `recordCreated(bytes)` after storing the secret
- `retrieve()` and `retrieveJson()` call `recordRetrieved(bytes)` on success
- Both retrieval methods call `recordExpired()` when the verifier or secret key is missing (lazy expired-without-retrieval detection)

### Updated: `ServerRoutes`
- `createSecret()`, `retrieveSecret()`, and `retrieveSecretJson()` now accept a `MetricsService` parameter
- New `metricsEndpoint()` handler for `GET /api/metrics` (accepts optional `?date=YYYY-MM-DD`)

### Updated: `server.php`
- Instantiates `MetricsService` and passes it to all relevant route handlers
- Registers `GET /api/metrics` route

### New: `MetricsServiceTest`
- 8 unit tests covering all counter methods and `getMetrics()` query behaviour

## Acceptance Criteria

- ✅ Creating secrets increments `metrics:created:YYYY-MM-DD` and `metrics:bytes_stored:YYYY-MM-DD`
- ✅ Retrieving secrets increments `metrics:retrieved:YYYY-MM-DD` and `metrics:bytes_retrieved:YYYY-MM-DD`
- ✅ Expired-without-retrieval events increment `metrics:expired:YYYY-MM-DD` (lazy detection)
- ✅ Counters are queryable via `GET /api/metrics`
- ✅ All 32 tests pass