### PR TITLE
DIS-845: Add IP-based rate limiting to /api/retrieve endpoint

### DIFF
--- a/server/src/RateLimiter.php
+++ b/server/src/RateLimiter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Swordfish\Server;
+
+use Predis\Client;
+
+class RateLimiter
+{
+    private const LIMIT = 30;
+    private const WINDOW = 60;
+
+    public function __construct(private Client $redis) {}
+
+    /**
+     * Check whether the given IP is within the rate limit for the current minute window.
+     *
+     * Uses a Redis counter keyed by IP and minute window. The counter is set to expire
+     * after WINDOW seconds so keys clean up automatically.
+     *
+     * @param string $ip Client IP address
+     * @return bool true if the request is allowed, false if the limit is exceeded
+     */
+    public function isAllowed(string $ip): bool
+    {
+        $window = (int) floor(time() / self::WINDOW);
+        $key    = "rate_limit:{$ip}:{$window}";
+
+        $count = (int) $this->redis->incr($key);
+        if ($count === 1) {
+            $this->redis->expire($key, self::WINDOW);
+        }
+
+        return $count <= self::LIMIT;
+    }
+}

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -205,8 +205,9 @@ class ServerRoutes
      * Accepts: {"id": "...", "verifier": "..."}
      * Returns: {"encrypted_secret": "...", "views_remaining": N, "expires_at": T}
      *
-     * Verifies the bcrypt-hashed verifier, decrements the view counter, and
-     * deletes all keys for the secret when views are exhausted.
+     * Enforces a rate limit of 30 requests per minute per IP. Verifies the
+     * bcrypt-hashed verifier, decrements the view counter, and deletes all keys
+     * for the secret when views are exhausted.
      *
      * @param Logger $logger
      * @param Client $redisClient
@@ -214,9 +215,20 @@ class ServerRoutes
      */
     public static function retrieveSecretJson(Logger $logger, Client $redisClient): CallableRequestHandler
     {
-        $service = new SecretService($redisClient);
-        return new CallableRequestHandler(function (Request $request) use ($logger, $service) {
-            $data = yield $request->getBody()->read();
+        $service     = new SecretService($redisClient);
+        $rateLimiter = new RateLimiter($redisClient);
+        return new CallableRequestHandler(function (Request $request) use ($logger, $service, $rateLimiter) {
+            $ip = $request->getClient()->getRemoteAddress()->getHost();
+            if (!$rateLimiter->isAllowed($ip)) {
+                $logger->warning(sprintf('Rate limit exceeded for IP %s on /api/retrieve', $ip));
+                return new Response(
+                    Status::TOO_MANY_REQUESTS,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Too Many Requests'])
+                );
+            }
+
+            $data = (string) yield $request->getBody()->read();
 
             $parsed = json_decode($data, true);
             if ($parsed === null || !isset($parsed['id'], $parsed['verifier'])) {

--- a/server/tests/Unit/RateLimiterTest.php
+++ b/server/tests/Unit/RateLimiterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\RateLimiter;
+
+class RateLimiterTest extends TestCase
+{
+    private function makeRedisMock(): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['incr', 'expire'])
+            ->getMock();
+    }
+
+    public function testAllowsRequestWhenUnderLimit(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('incr')->willReturn(1);
+
+        $limiter = new RateLimiter($redis);
+
+        $this->assertTrue($limiter->isAllowed('192.168.1.1'));
+    }
+
+    public function testAllowsRequestAtExactLimit(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('incr')->willReturn(30);
+
+        $limiter = new RateLimiter($redis);
+
+        $this->assertTrue($limiter->isAllowed('192.168.1.1'));
+    }
+
+    public function testDeniesRequestWhenLimitExceeded(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('incr')->willReturn(31);
+
+        $limiter = new RateLimiter($redis);
+
+        $this->assertFalse($limiter->isAllowed('192.168.1.1'));
+    }
+
+    public function testSetsExpireOnFirstRequest(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('incr')->willReturn(1);
+        $redis->expects($this->once())->method('expire')->with(
+            $this->stringContains('rate_limit:10.0.0.1:'),
+            60
+        );
+
+        $limiter = new RateLimiter($redis);
+        $limiter->isAllowed('10.0.0.1');
+    }
+
+    public function testDoesNotSetExpireOnSubsequentRequests(): void
+    {
+        $redis = $this->makeRedisMock();
+        $redis->method('incr')->willReturn(5);
+        $redis->expects($this->never())->method('expire');
+
+        $limiter = new RateLimiter($redis);
+        $limiter->isAllowed('10.0.0.1');
+    }
+
+    public function testKeyIncludesIpAndWindow(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedKey = null;
+        $redis->method('incr')->willReturnCallback(function (string $key) use (&$capturedKey) {
+            $capturedKey = $key;
+            return 1;
+        });
+        $redis->method('expire');
+
+        $limiter = new RateLimiter($redis);
+        $limiter->isAllowed('172.16.0.5');
+
+        $this->assertNotNull($capturedKey);
+        $this->assertStringStartsWith('rate_limit:172.16.0.5:', $capturedKey);
+
+        $expectedWindow = (int) floor(time() / 60);
+        $this->assertStringEndsWith((string) $expectedWindow, $capturedKey);
+    }
+}

--- a/server/tests/Unit/RetrieveRateLimitTest.php
+++ b/server/tests/Unit/RetrieveRateLimitTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use Amp\Http\Server\Driver\Client;
+use Amp\Http\Server\Request;
+use Amp\Http\Status;
+use Amp\Socket\SocketAddress;
+use League\Uri\Http;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\ServerRoutes;
+
+class RetrieveRateLimitTest extends TestCase
+{
+    private function makeRedisMock(int $incrReturn): RedisClient
+    {
+        $redis = $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['incr', 'expire'])
+            ->getMock();
+        $redis->method('incr')->willReturn($incrReturn);
+        return $redis;
+    }
+
+    private function makeRequest(string $ip = '127.0.0.1'): Request
+    {
+        $socketAddress = new SocketAddress($ip, 54321);
+        $client        = $this->createMock(Client::class);
+        $client->method('getRemoteAddress')->willReturn($socketAddress);
+        return new Request($client, 'POST', Http::new('http://localhost/api/retrieve'));
+    }
+
+    public function testReturns429WhenRateLimitExceeded(): void
+    {
+        $logger  = new Logger('test');
+        $redis   = $this->makeRedisMock(31);
+
+        $handler  = ServerRoutes::retrieveSecretJson($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+
+        $this->assertSame(Status::TOO_MANY_REQUESTS, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body = \Amp\Promise\wait($response->getBody()->read());
+        $this->assertSame(['error' => 'Too Many Requests'], json_decode($body, true));
+    }
+
+    public function testReturns429AtLimitPlusOne(): void
+    {
+        $logger  = new Logger('test');
+        $redis   = $this->makeRedisMock(31);
+
+        $handler  = ServerRoutes::retrieveSecretJson($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest('10.0.0.1')));
+
+        $this->assertSame(Status::TOO_MANY_REQUESTS, $response->getStatus());
+    }
+
+    public function testDoesNotReturn429WhenUnderLimit(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['incr', 'expire', 'get'])
+            ->getMock();
+        $redis->method('incr')->willReturn(1);
+        $redis->method('get')->willReturn(null); // secret not found → 400 bad request path
+
+        $handler  = ServerRoutes::retrieveSecretJson($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+
+        $this->assertNotSame(Status::TOO_MANY_REQUESTS, $response->getStatus());
+    }
+}


### PR DESCRIPTION
## Summary

Implements IP-based rate limiting on `POST /api/retrieve` using Redis counters.

## Changes

- **`server/src/RateLimiter.php`** — New class that tracks request counts per IP per 60-second window using Redis `INCR` + `EXPIRE`. Allows up to 30 requests per minute.
- **`server/src/ServerRoutes.php`** — Wires `RateLimiter` into `retrieveSecretJson` before body parsing; returns `429 Too Many Requests` (JSON) when the limit is exceeded. Also fixes a pre-existing `json_decode(null)` deprecation.
- **`server/tests/Unit/RateLimiterTest.php`** — Unit tests for `RateLimiter`: allow under limit, allow at exact limit, deny over limit, expire set on first request only, key format.
- **`server/tests/Unit/RetrieveRateLimitTest.php`** — Route handler tests: 429 returned when limit exceeded, non-429 returned when under limit.

## Acceptance Criteria

- [x] Exceeding 30 retrieve requests per minute from one IP returns 429
- [x] Normal usage (≤30 req/min) is unaffected

Resolves: [DIS-845](https://linear.app/displace-tech/issue/DIS-845/add-rate-limiting-to-retrieval-endpoint)