### PR TITLE
DIS-849: Implement configurable view limits

### DIFF
--- a/server/src/CreateRequest.php
+++ b/server/src/CreateRequest.php
@@ -6,18 +6,21 @@ class CreateRequest
 {
     const DEFAULT_TTL = 86400;
     const MAX_TTL = 604800;
+    const ALLOWED_MAX_VIEWS = [0, 1, 3, 5, 10];
 
     protected string $salt;
     protected string $verifier;
     protected string $secret;
     protected int $ttl;
+    protected int $maxViews;
 
-    public function __construct(string $salt, string $verifier, string $secret, int $ttl = self::DEFAULT_TTL)
+    public function __construct(string $salt, string $verifier, string $secret, int $ttl = self::DEFAULT_TTL, int $maxViews = 0)
     {
         $this->salt = $salt;
         $this->verifier = $verifier;
         $this->secret = $secret;
         $this->ttl = $ttl;
+        $this->maxViews = $maxViews;
     }
 
     /**
@@ -51,11 +54,24 @@ class CreateRequest
     }
 
     /**
+     * Return the maximum number of views allowed (0 = unlimited).
+     *
+     * @return int
+     */
+    public function maxViews(): int
+    {
+        return $this->maxViews;
+    }
+
+    /**
      * Deserialize a request and create a new object from it.
+     *
+     * Format: hex(salt)$hex(verifier)$hex(secret)[$ttl[$max_views]]
      *
      * @param string $raw
      *
      * @throws \Exception
+     * @throws \InvalidArgumentException
      *
      * @return CreateRequest
      */
@@ -63,7 +79,7 @@ class CreateRequest
     {
        $parts = explode('$', $raw);
 
-       if (sizeof($parts) < 3 || sizeof($parts) > 4) {
+       if (sizeof($parts) < 3 || sizeof($parts) > 5) {
            throw new \Exception('Invalid serialized request!');
        }
 
@@ -80,13 +96,21 @@ class CreateRequest
        }
 
        $ttl = self::DEFAULT_TTL;
-       if (sizeof($parts) === 4) {
+       if (sizeof($parts) >= 4) {
            $ttl = (int) $parts[3];
            if ($ttl < 1 || $ttl > self::MAX_TTL) {
                throw new \InvalidArgumentException(sprintf('TTL must be between 1 and %d seconds.', self::MAX_TTL));
            }
        }
 
-       return new self($salt, $verifier, $secret, $ttl);
+       $maxViews = 0;
+       if (sizeof($parts) === 5) {
+           $maxViews = (int) $parts[4];
+           if (!in_array($maxViews, self::ALLOWED_MAX_VIEWS, true)) {
+               throw new \InvalidArgumentException(sprintf('max_views must be one of: %s.', implode(', ', self::ALLOWED_MAX_VIEWS)));
+           }
+       }
+
+       return new self($salt, $verifier, $secret, $ttl, $maxViews);
     }
 }

--- a/server/src/SecretService.php
+++ b/server/src/SecretService.php
@@ -31,6 +31,38 @@ class SecretService
     }
 
     /**
+     * Store a new JSON-API secret with view counter and expiry metadata.
+     *
+     * Generates a random 12-character hex ID and stores the verifier hash,
+     * secret payload, expiry timestamp, and (when limited) view counter in Redis.
+     * When max_views is 0 the secret has unlimited views.
+     *
+     * @param CreateRequest $request
+     * @return string The generated secret ID
+     */
+    public function createJson(CreateRequest $request): string
+    {
+        $secretID    = bin2hex(random_bytes(6));
+        $secretKey   = "json_secret:{$secretID}";
+        $verifierKey = "json_verifier:{$secretID}";
+        $viewsKey    = "json_views:{$secretID}";
+        $expiresKey  = "json_expires:{$secretID}";
+        $ttl         = $request->ttl();
+        $maxViews    = $request->maxViews();
+        $expiresAt   = time() + $ttl;
+
+        $this->redis->setex($verifierKey, $ttl, $request->verifier());
+        $this->redis->setex($secretKey, $ttl + 30, $request->secret());
+        $this->redis->setex($expiresKey, $ttl + 30, (string) $expiresAt);
+
+        if ($maxViews > 0) {
+            $this->redis->setex($viewsKey, $ttl, (string) $maxViews);
+        }
+
+        return $secretID;
+    }
+
+    /**
      * Retrieve a v1 secret after verifying the supplied password.
      *
      * @param string $secretID
@@ -66,11 +98,12 @@ class SecretService
      * Retrieve a JSON-API secret after verifying the supplied verifier.
      *
      * Decrements the view counter and deletes all associated keys when views
-     * are exhausted.
+     * are exhausted. When no views key exists the secret has unlimited views
+     * and views_remaining is returned as null.
      *
      * @param string $secretID
      * @param string $verifier Plain-text verifier submitted by the client
-     * @return array{encrypted_secret: string, views_remaining: int, expires_at: int}
+     * @return array{encrypted_secret: string, views_remaining: int|null, expires_at: int}
      *
      * @throws SecretNotFoundException  When the verifier or secret key is absent
      * @throws InvalidVerifierException When the verifier does not match the stored hash
@@ -96,16 +129,23 @@ class SecretService
             throw new SecretNotFoundException(sprintf('JSON secret %s not found.', $secretID));
         }
 
-        $expiresAt  = (int) $this->redis->get($expiresKey);
-        $viewsAfter = (int) $this->redis->decr($viewsKey);
+        $expiresAt = (int) $this->redis->get($expiresKey);
 
-        if ($viewsAfter <= 0) {
-            $this->redis->del($secretKey, $verifierKey, $viewsKey, $expiresKey);
+        $viewsRaw = $this->redis->get($viewsKey);
+        if ($viewsRaw === null) {
+            // Unlimited views — no counter to decrement
+            $viewsRemaining = null;
+        } else {
+            $viewsAfter = (int) $this->redis->decr($viewsKey);
+            if ($viewsAfter <= 0) {
+                $this->redis->del($secretKey, $verifierKey, $viewsKey, $expiresKey);
+            }
+            $viewsRemaining = max(0, $viewsAfter);
         }
 
         return [
             'encrypted_secret' => $encryptedSecret,
-            'views_remaining'  => max(0, $viewsAfter),
+            'views_remaining'  => $viewsRemaining,
             'expires_at'       => $expiresAt,
         ];
     }

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -119,14 +119,14 @@ class ServerRoutes
             try {
                 $secretRequest = CreateRequest::fromString($data);
             } catch (\InvalidArgumentException $e) {
-                $logger->error('Invalid TTL in creation request: ' . $e->getMessage());
+                $logger->error('Invalid parameter in creation request: ' . $e->getMessage());
                 return new Response(Status::UNPROCESSABLE_ENTITY, ['content-type' => 'application/json'], json_encode(['error' => $e->getMessage()]));
             } catch (\Exception $e) {
                 $logger->error('Unable to decode creation request');
                 return new Response(Status::BAD_REQUEST, ['content-type' => 'text/plain'], 'Bad Request');
             }
 
-            $secretID = $service->create($secretRequest);
+            $secretID = $service->createJson($secretRequest);
             $logger->info(sprintf('Created secret %s', $secretID));
 
             return new Response(Status::CREATED, ['content-type' => 'text/plain'], $secretID);

--- a/server/tests/Unit/CreateRequestTest.php
+++ b/server/tests/Unit/CreateRequestTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Swordfish\Server\CreateRequest;
+
+class CreateRequestTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // max_views default and getter
+    // -------------------------------------------------------------------------
+
+    public function testDefaultMaxViewsIsZero(): void
+    {
+        $request = new CreateRequest(
+            str_repeat('a', 16),
+            str_repeat('b', 32),
+            'secret'
+        );
+
+        $this->assertSame(0, $request->maxViews());
+    }
+
+    public function testConstructorAcceptsMaxViews(): void
+    {
+        foreach ([0, 1, 3, 5, 10] as $maxViews) {
+            $request = new CreateRequest(
+                str_repeat('a', 16),
+                str_repeat('b', 32),
+                'secret',
+                CreateRequest::DEFAULT_TTL,
+                $maxViews
+            );
+            $this->assertSame($maxViews, $request->maxViews());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // fromString() — max_views parsing
+    // -------------------------------------------------------------------------
+
+    public function testFromStringWithoutMaxViewsDefaultsToZero(): void
+    {
+        $salt     = bin2hex(str_repeat('a', 16));
+        $verifier = bin2hex(str_repeat('b', 32));
+        $secret   = bin2hex('mysecret');
+
+        $request = CreateRequest::fromString("{$salt}\${$verifier}\${$secret}");
+
+        $this->assertSame(0, $request->maxViews());
+    }
+
+    public function testFromStringParsesMaxViewsSegment(): void
+    {
+        $salt     = bin2hex(str_repeat('a', 16));
+        $verifier = bin2hex(str_repeat('b', 32));
+        $secret   = bin2hex('mysecret');
+        $ttl      = 3600;
+
+        foreach ([1, 3, 5, 10] as $maxViews) {
+            $request = CreateRequest::fromString("{$salt}\${$verifier}\${$secret}\${$ttl}\${$maxViews}");
+            $this->assertSame($maxViews, $request->maxViews());
+        }
+    }
+
+    public function testFromStringAcceptsZeroMaxViewsForUnlimited(): void
+    {
+        $salt     = bin2hex(str_repeat('a', 16));
+        $verifier = bin2hex(str_repeat('b', 32));
+        $secret   = bin2hex('mysecret');
+
+        $request = CreateRequest::fromString("{$salt}\${$verifier}\${$secret}\$3600\$0");
+
+        $this->assertSame(0, $request->maxViews());
+    }
+
+    /**
+     * @dataProvider invalidMaxViewsProvider
+     */
+    public function testFromStringRejectsInvalidMaxViews(int $invalid): void
+    {
+        $salt     = bin2hex(str_repeat('a', 16));
+        $verifier = bin2hex(str_repeat('b', 32));
+        $secret   = bin2hex('mysecret');
+
+        $this->expectException(\InvalidArgumentException::class);
+        CreateRequest::fromString("{$salt}\${$verifier}\${$secret}\$3600\${$invalid}");
+    }
+
+    public static function invalidMaxViewsProvider(): array
+    {
+        return [[2], [4], [6], [7], [11], [100]];
+    }
+
+    public function testFromStringRejectsTooManySegments(): void
+    {
+        $salt     = bin2hex(str_repeat('a', 16));
+        $verifier = bin2hex(str_repeat('b', 32));
+        $secret   = bin2hex('mysecret');
+
+        $this->expectException(\Exception::class);
+        CreateRequest::fromString("{$salt}\${$verifier}\${$secret}\$3600\$5\$extra");
+    }
+}

--- a/server/tests/Unit/SecretServiceTest.php
+++ b/server/tests/Unit/SecretServiceTest.php
@@ -217,6 +217,9 @@ class SecretServiceTest extends TestCase
                 if (str_starts_with($key, 'json_expires:')) {
                     return '9999999999';
                 }
+                if (str_starts_with($key, 'json_views:')) {
+                    return '3'; // limited: 3 views remaining before this retrieval
+                }
                 return null;
             });
 
@@ -251,6 +254,9 @@ class SecretServiceTest extends TestCase
                 if (str_starts_with($key, 'json_expires:')) {
                     return '9999999999';
                 }
+                if (str_starts_with($key, 'json_views:')) {
+                    return '1'; // last view
+                }
                 return null;
             });
 
@@ -262,5 +268,130 @@ class SecretServiceTest extends TestCase
         $result  = $service->retrieveJson('abc123def456', $verifier);
 
         $this->assertSame(0, $result['views_remaining']);
+    }
+
+    public function testRetrieveJsonReturnsNullViewsRemainingForUnlimitedSecret(): void
+    {
+        $redis    = $this->makeRedisMock();
+        $verifier = 'my-verifier';
+        $hash     = password_hash($verifier, PASSWORD_DEFAULT);
+
+        $redis->method('get')
+            ->willReturnCallback(function (string $key) use ($hash) {
+                if (str_starts_with($key, 'json_verifier:')) {
+                    return $hash;
+                }
+                if (str_starts_with($key, 'json_secret:')) {
+                    return 'encrypted-payload';
+                }
+                if (str_starts_with($key, 'json_expires:')) {
+                    return '9999999999';
+                }
+                return null; // no views key → unlimited
+            });
+
+        $redis->expects($this->never())->method('decr');
+        $redis->expects($this->never())->method('del');
+
+        $service = new SecretService($redis);
+        $result  = $service->retrieveJson('abc123def456', $verifier);
+
+        $this->assertSame('encrypted-payload', $result['encrypted_secret']);
+        $this->assertNull($result['views_remaining']);
+        $this->assertSame(9999999999, $result['expires_at']);
+    }
+
+    // -------------------------------------------------------------------------
+    // createJson()
+    // -------------------------------------------------------------------------
+
+    public function testCreateJsonStoresVerifierSecretAndExpiresKeys(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->expects($this->exactly(3))
+            ->method('setex')
+            ->willReturnCallback(function (string $key, int $ttl, string $value) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'ttl' => $ttl];
+            });
+
+        $service = new SecretService($redis);
+        $request = new CreateRequest(
+            str_repeat('a', 16),
+            str_repeat('b', 32),
+            'my-secret-payload',
+            3600,
+            0 // unlimited
+        );
+
+        $secretID = $service->createJson($request);
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{12}$/', $secretID);
+
+        $keys = array_column($capturedCalls, 'key');
+        $this->assertContains("json_verifier:{$secretID}", $keys);
+        $this->assertContains("json_secret:{$secretID}", $keys);
+        $this->assertContains("json_expires:{$secretID}", $keys);
+        $this->assertNotContains("json_views:{$secretID}", $keys);
+    }
+
+    public function testCreateJsonStoresViewsKeyForLimitedViews(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->expects($this->exactly(4))
+            ->method('setex')
+            ->willReturnCallback(function (string $key, int $ttl, string $value) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'ttl' => $ttl, 'value' => $value];
+            });
+
+        $service = new SecretService($redis);
+        $request = new CreateRequest(
+            str_repeat('a', 16),
+            str_repeat('b', 32),
+            'my-secret-payload',
+            3600,
+            5 // 5 views
+        );
+
+        $secretID = $service->createJson($request);
+
+        $keys = array_column($capturedCalls, 'key');
+        $this->assertContains("json_views:{$secretID}", $keys);
+
+        $viewsCall = array_values(array_filter($capturedCalls, fn($c) => $c['key'] === "json_views:{$secretID}"));
+        $this->assertCount(1, $viewsCall);
+        $this->assertSame('5', $viewsCall[0]['value']);
+        $this->assertSame(3600, $viewsCall[0]['ttl']);
+    }
+
+    public function testCreateJsonUsesRequestTtlForVerifierKey(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->expects($this->exactly(3))
+            ->method('setex')
+            ->willReturnCallback(function (string $key, int $ttl, string $value) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'ttl' => $ttl];
+            });
+
+        $service = new SecretService($redis);
+        $request = new CreateRequest(
+            str_repeat('a', 16),
+            str_repeat('b', 32),
+            'payload',
+            7200
+        );
+
+        $secretID = $service->createJson($request);
+
+        $verifierCall = array_values(array_filter($capturedCalls, fn($c) => $c['key'] === "json_verifier:{$secretID}"));
+        $secretCall   = array_values(array_filter($capturedCalls, fn($c) => $c['key'] === "json_secret:{$secretID}"));
+
+        $this->assertSame(7200, $verifierCall[0]['ttl']);
+        $this->assertSame(7230, $secretCall[0]['ttl']);
     }
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -134,8 +134,9 @@ paths:
         - in: "body"
           name: "body"
           description: |
-            Serialized secret to store in the server. Format: hex(salt)$hex(verifier)$hex(secret)[$ttl]
+            Serialized secret to store in the server. Format: hex(salt)$hex(verifier)$hex(secret)[$ttl[$max_views]]
             The optional TTL field specifies the secret lifetime in seconds (1–604800). Defaults to 86400.
+            The optional max_views field limits how many times the secret may be retrieved. Allowed values: 1, 3, 5, 10, or 0 (unlimited, default).
           required: true
           schema:
             type: "string"
@@ -147,7 +148,7 @@ paths:
         "413":
           description: "Payload Too Large"
         "422":
-          description: "Unprocessable Entity — TTL out of range"
+          description: "Unprocessable Entity — TTL out of range or invalid max_views"
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."
@@ -185,7 +186,8 @@ paths:
                 description: "The encrypted secret payload"
               views_remaining:
                 type: "integer"
-                description: "Number of views remaining after this retrieval"
+                description: "Number of views remaining after this retrieval; null for unlimited secrets"
+                x-nullable: true
               expires_at:
                 type: "integer"
                 description: "Unix timestamp when the secret expires"


### PR DESCRIPTION
## DIS-849: Implement configurable view limits

Linear: https://linear.app/displace-tech/issue/DIS-849/implement-configurable-view-limits

### Summary

Implements configurable view limits for secrets created via `POST /api/create`.

### Changes

**`CreateRequest`**
- Added `max_views` parameter to the serialized format: `hex(salt)$hex(verifier)$hex(secret)[$ttl[$max_views]]`
- Allowed values: `1`, `3`, `5`, `10`, or `0` / omitted for unlimited
- Validation rejects any other value with a 422 response

**`SecretService`**
- Added `createJson()` method that stores `json_verifier:{id}`, `json_secret:{id}`, `json_expires:{id}`, and (when limited) `json_views:{id}` keys in Redis with the requested TTL
- Updated `retrieveJson()` to handle unlimited secrets: when no `json_views:{id}` key exists, the view counter is not decremented and `views_remaining` is returned as `null`
- Updated `ServerRoutes::createSecret()` to call `createJson()` so the create and retrieve endpoints share the same Redis key namespace

**Tests**
- Added `CreateRequestTest` covering `max_views` defaults, valid values, parsing, and rejection of invalid values
- Added `SecretServiceTest` cases for `createJson()` (unlimited and limited) and the unlimited retrieval path
- Updated existing `retrieveJson` tests to supply a `json_views:` key value, matching the new two-step get-then-decrement logic

**`swagger.yml`**
- Documented `max_views` in the `/api/create` body format description
- Noted that `views_remaining` is nullable (null for unlimited secrets)

### Acceptance Criteria

- [x] View-limited secrets are deleted after max views exhausted
- [x] Unlimited secrets behave as v1 (no deletion, `views_remaining: null`)
- [x] `views_remaining` is returned on retrieve
- [x] All tests pass