### PR TITLE
DIS-878: Migrate API routes to /api/ prefix with backward-compatible redirects

### DIFF
--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -72,7 +72,7 @@ class ServerRoutes
     }
 
     /**
-     * Redirect POST /create to POST /api/create with a 307 Temporary Redirect.
+     * Redirect POST /create to POST /api/create with a 308 Permanent Redirect.
      *
      * @param Logger $logger
      * @return CallableRequestHandler
@@ -81,12 +81,12 @@ class ServerRoutes
     {
         return new CallableRequestHandler(function() use ($logger): Response {
             $logger->info('Redirecting POST /create to POST /api/create');
-            return new Response(Status::TEMPORARY_REDIRECT, ['location' => '/api/create'], '');
+            return new Response(Status::PERMANENT_REDIRECT, ['location' => '/api/create'], '');
         });
     }
 
     /**
-     * Redirect POST /retrieve to POST /api/retrieve with a 307 Temporary Redirect.
+     * Redirect POST /retrieve to POST /api/retrieve with a 308 Permanent Redirect.
      *
      * @param Logger $logger
      * @return CallableRequestHandler
@@ -95,7 +95,7 @@ class ServerRoutes
     {
         return new CallableRequestHandler(function() use ($logger): Response {
             $logger->info('Redirecting POST /retrieve to POST /api/retrieve');
-            return new Response(Status::TEMPORARY_REDIRECT, ['location' => '/api/retrieve'], '');
+            return new Response(Status::PERMANENT_REDIRECT, ['location' => '/api/retrieve'], '');
         });
     }
 

--- a/server/tests/Unit/RedirectTest.php
+++ b/server/tests/Unit/RedirectTest.php
@@ -20,23 +20,23 @@ class RedirectTest extends TestCase
         return new Request($client, 'POST', Http::new('http://localhost' . $path));
     }
 
-    public function testRedirectCreateReturns307ToApiCreate(): void
+    public function testRedirectCreateReturns308ToApiCreate(): void
     {
         $logger   = new Logger('test');
         $handler  = ServerRoutes::redirectCreate($logger);
         $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest('/create')));
 
-        $this->assertSame(Status::TEMPORARY_REDIRECT, $response->getStatus());
+        $this->assertSame(Status::PERMANENT_REDIRECT, $response->getStatus());
         $this->assertSame('/api/create', $response->getHeader('location'));
     }
 
-    public function testRedirectRetrieveReturns307ToApiRetrieve(): void
+    public function testRedirectRetrieveReturns308ToApiRetrieve(): void
     {
         $logger   = new Logger('test');
         $handler  = ServerRoutes::redirectRetrieve($logger);
         $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest('/retrieve')));
 
-        $this->assertSame(Status::TEMPORARY_REDIRECT, $response->getStatus());
+        $this->assertSame(Status::PERMANENT_REDIRECT, $response->getStatus());
         $this->assertSame('/api/retrieve', $response->getHeader('location'));
     }
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -100,8 +100,8 @@ paths:
           schema:
             type: "string"
       responses:
-        "307":
-          description: "Temporary Redirect to /api/create"
+        "308":
+          description: "Permanent Redirect to /api/create"
   /retrieve:
     post:
       summary: "Retrieve a secret (deprecated — redirects to /api/retrieve)."
@@ -119,8 +119,8 @@ paths:
           schema:
             type: "object"
       responses:
-        "307":
-          description: "Temporary Redirect to /api/retrieve"
+        "308":
+          description: "Permanent Redirect to /api/retrieve"
   /api/create:
     post:
       summary: "Create a new secret in the datastore."


### PR DESCRIPTION
## Summary

Fixes the backward-compatible redirect status code for the legacy `/create` and `/retrieve` endpoints.

The `/api/create` and `/api/retrieve` routes were already in place. This PR corrects the redirect status from **307 Temporary Redirect** to **308 Permanent Redirect** as required by the acceptance criteria, ensuring clients that follow redirects will cache the redirect permanently and preserve the POST method and body per RFC 7538.

## Changes

- `server/src/ServerRoutes.php`: `redirectCreate` and `redirectRetrieve` now return `Status::PERMANENT_REDIRECT` (308)
- `server/tests/Unit/RedirectTest.php`: Updated assertions to expect 308
- `swagger.yml`: Updated `/create` and `/retrieve` response codes from `307` to `308`

## Acceptance Criteria

- [x] `POST /api/create` works
- [x] `POST /api/retrieve` works
- [x] `POST /create` returns 308 redirect to `/api/create`
- [x] `POST /retrieve` returns 308 redirect to `/api/retrieve`
- [x] Existing v1 clients still function (308 preserves POST method and body)

References: [DIS-878](https://linear.app/displace-tech/issue/DIS-878/migrate-api-routes-to-api-prefix-with-backward-compatible-redirects)