### PR TITLE
DIS-886: Port encryption/decryption logic to ES module

### DIFF
--- a/frontend/src/__tests__/crypto.test.ts
+++ b/frontend/src/__tests__/crypto.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { encrypt, decrypt } from '../crypto'
+
+describe('crypto', () => {
+  it('encrypt produces a valid v1 wire-format creation string', async () => {
+    const creationString = await encrypt('hello, world!', 'test-passphrase')
+
+    // Format: hex(salt)$hex(verifier)$hex(nonce)hex(ciphertext)
+    const parts = creationString.split('$')
+    expect(parts).toHaveLength(3)
+
+    const [saltHex, verifierHex, payloadHex] = parts
+
+    // salt = 16 bytes → 32 hex chars
+    expect(saltHex).toHaveLength(32)
+    expect(saltHex).toMatch(/^[0-9a-f]+$/)
+
+    // verifier = 32 bytes (256 bits) → 64 hex chars
+    expect(verifierHex).toHaveLength(64)
+    expect(verifierHex).toMatch(/^[0-9a-f]+$/)
+
+    // payload = nonce (12 bytes = 24 hex) + ciphertext (≥ 1 byte)
+    expect(payloadHex.length).toBeGreaterThan(24)
+    expect(payloadHex).toMatch(/^[0-9a-f]+$/)
+  })
+
+  it('round-trips plaintext through encrypt then decrypt', async () => {
+    const plaintext = 'my secret message'
+    const passphrase = 'correct-passphrase'
+
+    const creationString = await encrypt(plaintext, passphrase)
+
+    // Reconstruct the server blob: hex(salt + nonce + ciphertext)
+    // Creation string: hex(salt)$hex(verifier)$hex(nonce)hex(ciphertext)
+    // Server stores:   hex(salt + nonce + ciphertext) = saltHex + payloadHex
+    const parts = creationString.split('$')
+    const blob = parts[0] + parts[2]
+
+    const decrypted = await decrypt(blob, passphrase)
+    expect(decrypted).toBe(plaintext)
+  })
+
+  it('produces a different ciphertext each call (random salt and nonce)', async () => {
+    const plaintext = 'same message'
+    const passphrase = 'same-passphrase'
+
+    const first = await encrypt(plaintext, passphrase)
+    const second = await encrypt(plaintext, passphrase)
+
+    expect(first).not.toBe(second)
+  })
+
+  it('rejects decryption with a wrong passphrase', async () => {
+    const creationString = await encrypt('secret', 'correct')
+    const parts = creationString.split('$')
+    const blob = parts[0] + parts[2]
+
+    await expect(decrypt(blob, 'wrong')).rejects.toThrow()
+  })
+
+  it('verifier is deterministic for the same passphrase (pepper-based)', async () => {
+    const first = await encrypt('msg1', 'my-passphrase')
+    const second = await encrypt('msg2', 'my-passphrase')
+
+    const verifier1 = first.split('$')[1]
+    const verifier2 = second.split('$')[1]
+
+    // Same passphrase → same verifier (PBKDF2 over fixed pepper)
+    expect(verifier1).toBe(verifier2)
+  })
+})

--- a/frontend/src/crypto.ts
+++ b/frontend/src/crypto.ts
@@ -1,0 +1,93 @@
+const PEPPER = new TextEncoder().encode('d783eff0523c8fa7336bc768c5950f63')
+const PBKDF2_ITERATIONS = 10000
+
+function toHex(buffer: ArrayBuffer | Uint8Array): string {
+  return Array.from(new Uint8Array(buffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function fromHex(hex: string): Uint8Array {
+  const matches = hex.match(/.{1,2}/g)
+  if (!matches) throw new Error('Invalid hex string')
+  return new Uint8Array(matches.map(b => parseInt(b, 16)))
+}
+
+async function importPassphrase(passphrase: string): Promise<CryptoKey> {
+  return globalThis.crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(passphrase),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveBits', 'deriveKey'],
+  )
+}
+
+async function deriveVerifier(passkey: CryptoKey): Promise<ArrayBuffer> {
+  return globalThis.crypto.subtle.deriveBits(
+    { name: 'PBKDF2', salt: PEPPER, iterations: PBKDF2_ITERATIONS, hash: 'SHA-256' },
+    passkey,
+    256,
+  )
+}
+
+async function deriveKey(passkey: CryptoKey, salt: Uint8Array): Promise<CryptoKey> {
+  return globalThis.crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: PBKDF2_ITERATIONS, hash: 'SHA-256' },
+    passkey,
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+/**
+ * Encrypt a plaintext secret with a passphrase.
+ *
+ * Returns a wire-format creation string compatible with the v1 server:
+ *   hex(salt) + '$' + hex(verifier) + '$' + hex(nonce) + hex(ciphertext)
+ *
+ * The verifier is a PBKDF2 digest over the pepper used by the server to
+ * authenticate retrieval requests without storing the passphrase.
+ */
+export async function encrypt(plaintext: string, passphrase: string): Promise<string> {
+  const salt = globalThis.crypto.getRandomValues(new Uint8Array(16))
+  const nonce = globalThis.crypto.getRandomValues(new Uint8Array(12))
+
+  const passkey = await importPassphrase(passphrase)
+  const verifier = await deriveVerifier(passkey)
+  const key = await deriveKey(passkey, salt)
+
+  const ciphertext = await globalThis.crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: nonce },
+    key,
+    new TextEncoder().encode(plaintext),
+  )
+
+  const payload = toHex(nonce) + toHex(ciphertext)
+  return `${toHex(salt)}$${toHex(verifier)}$${payload}`
+}
+
+/**
+ * Decrypt a ciphertext blob returned by the server with a passphrase.
+ *
+ * The blob is the hex-encoded concatenation of salt (16 bytes), nonce (12 bytes),
+ * and AES-GCM ciphertext, matching the format stored and returned by the v1 server.
+ */
+export async function decrypt(blob: string, passphrase: string): Promise<string> {
+  const decoded = fromHex(blob)
+  const salt = decoded.slice(0, 16)
+  const nonce = decoded.slice(16, 28)
+  const encrypted = decoded.slice(28)
+
+  const passkey = await importPassphrase(passphrase)
+  const key = await deriveKey(passkey, salt)
+
+  const plaintext = await globalThis.crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: nonce },
+    key,
+    encrypted,
+  )
+
+  return new TextDecoder().decode(plaintext)
+}


### PR DESCRIPTION
## DIS-886: Port encryption/decryption logic to ES module

Linear: https://linear.app/displace-tech/issue/DIS-886/port-encryptiondecryption-logic-to-es-module

### Summary

Extracts the v1 Web Crypto API encryption flow into a clean TypeScript ES module (`frontend/src/crypto.ts`) with proper types.

### Changes

- **`frontend/src/crypto.ts`** — New ES module exporting:
  - `encrypt(plaintext: string, passphrase: string): Promise<string>` — Encrypts using AES-256-GCM with PBKDF2 key derivation (same pepper, salt, iterations as v1). Returns the v1 wire-format creation string: `hex(salt)$hex(verifier)$hex(nonce)hex(ciphertext)`.
  - `decrypt(blob: string, passphrase: string): Promise<string>` — Decrypts the hex blob returned by the server (`hex(salt + nonce + ciphertext)`), matching the format stored and returned by the v1 server.

- **`frontend/src/__tests__/crypto.test.ts`** — 5 tests covering:
  - Wire-format validity (correct lengths and hex encoding for all fields)
  - Round-trip correctness (encrypt → reconstruct blob → decrypt → original plaintext)
  - Randomness (different ciphertext each call due to random salt and nonce)
  - Wrong-passphrase rejection (AES-GCM authentication tag failure)
  - Deterministic verifier (same passphrase always produces the same PBKDF2 verifier over the fixed pepper)

### Compatibility

The output is byte-for-byte compatible with the v1 `common.js` + `create.js` + `retrieve.js` implementation:
- Same pepper: `d783eff0523c8fa7336bc768c5950f63`
- Same PBKDF2 parameters: SHA-256, 10 000 iterations, 256-bit output
- Same AES-GCM parameters: 256-bit key, 12-byte nonce
- Same hex-encoding wire format

### Test Results

All 6 tests pass (`npm test`), lint is clean (`npm run lint`), and the build succeeds (`npm run build`).