### PR TITLE
DIS-882: Switch API to JSON request/response format

### DIFF
--- a/server/src/CreateRequest.php
+++ b/server/src/CreateRequest.php
@@ -64,6 +64,61 @@ class CreateRequest
     }
 
     /**
+     * Deserialize a JSON API request and create a new object from it.
+     *
+     * Expects: {"encrypted_secret": "hex(salt)$hex(verifier)$hex(secret)", "ttl": N, "max_views": N}
+     *
+     * @param string $json
+     *
+     * @throws \Exception
+     * @throws \InvalidArgumentException
+     *
+     * @return CreateRequest
+     */
+    public static function fromJson(string $json): CreateRequest
+    {
+        $parsed = json_decode($json, true);
+        if ($parsed === null || !isset($parsed['encrypted_secret'])) {
+            throw new \Exception('Invalid JSON request!');
+        }
+
+        $parts = explode('$', $parsed['encrypted_secret']);
+        if (sizeof($parts) !== 3) {
+            throw new \Exception('Invalid encrypted_secret format!');
+        }
+
+        $salt     = hex2bin($parts[0]);
+        $verifier = hex2bin($parts[1]);
+        $secret   = hex2bin($parts[2]);
+
+        if (strlen($salt) !== 16) {
+            throw new \Exception('Invalid salt length!');
+        }
+
+        if (strlen($verifier) !== 32) {
+            throw new \Exception('Invalid verifier length!');
+        }
+
+        $ttl = self::DEFAULT_TTL;
+        if (isset($parsed['ttl'])) {
+            $ttl = (int) $parsed['ttl'];
+            if ($ttl < 1 || $ttl > self::MAX_TTL) {
+                throw new \InvalidArgumentException(sprintf('TTL must be between 1 and %d seconds.', self::MAX_TTL));
+            }
+        }
+
+        $maxViews = 0;
+        if (isset($parsed['max_views'])) {
+            $maxViews = (int) $parsed['max_views'];
+            if (!in_array($maxViews, self::ALLOWED_MAX_VIEWS, true)) {
+                throw new \InvalidArgumentException(sprintf('max_views must be one of: %s.', implode(', ', self::ALLOWED_MAX_VIEWS)));
+            }
+        }
+
+        return new self($salt, $verifier, $secret, $ttl, $maxViews);
+    }
+
+    /**
      * Deserialize a request and create a new object from it.
      *
      * Format: hex(salt)$hex(verifier)$hex(secret)[$ttl[$max_views]]

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -100,7 +100,10 @@ class ServerRoutes
     }
 
     /**
-     * Process a secret creation request and attempt to create the secret.
+     * Process a JSON secret creation request and return the new secret metadata.
+     *
+     * Accepts: {"encrypted_secret": "hex(salt)$hex(verifier)$hex(secret)", "ttl": N, "max_views": N}
+     * Returns: {"id": "...", "expires_at": T, "max_views": N}
      *
      * @param Logger $logger
      * @param Client $redisClient
@@ -113,23 +116,41 @@ class ServerRoutes
             $data = yield $request->getBody()->read();
             if (strlen($data) > 100 * 1000) {
                 $logger->error('Message payload too large!');
-                return new Response(Status::PAYLOAD_TOO_LARGE, ['content-type' => 'text/plain'], 'Payload Too Large');
+                return new Response(
+                    Status::PAYLOAD_TOO_LARGE,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Payload Too Large', 'message' => 'Request body exceeds maximum allowed size'])
+                );
             }
 
             try {
-                $secretRequest = CreateRequest::fromString($data);
+                $secretRequest = CreateRequest::fromJson($data);
             } catch (\InvalidArgumentException $e) {
                 $logger->error('Invalid parameter in creation request: ' . $e->getMessage());
-                return new Response(Status::UNPROCESSABLE_ENTITY, ['content-type' => 'application/json'], json_encode(['error' => $e->getMessage()]));
+                return new Response(
+                    Status::UNPROCESSABLE_ENTITY,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Unprocessable Entity', 'message' => $e->getMessage()])
+                );
             } catch (\Exception $e) {
-                $logger->error('Unable to decode creation request');
-                return new Response(Status::BAD_REQUEST, ['content-type' => 'text/plain'], 'Bad Request');
+                $logger->error('Unable to decode creation request: ' . $e->getMessage());
+                return new Response(
+                    Status::BAD_REQUEST,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Bad Request', 'message' => 'Invalid or missing JSON fields'])
+                );
             }
 
-            $secretID = $service->createJson($secretRequest);
-            $logger->info(sprintf('Created secret %s', $secretID));
+            $secretID  = $service->createJson($secretRequest);
+            $expiresAt = time() + $secretRequest->ttl();
+            $maxViews  = $secretRequest->maxViews();
+            $logger->info(sprintf('Created JSON secret %s', $secretID));
 
-            return new Response(Status::CREATED, ['content-type' => 'text/plain'], $secretID);
+            return new Response(
+                Status::CREATED,
+                ['content-type' => 'application/json'],
+                json_encode(['id' => $secretID, 'expires_at' => $expiresAt, 'max_views' => $maxViews])
+            );
         });
     }
 
@@ -224,7 +245,7 @@ class ServerRoutes
                 return new Response(
                     Status::TOO_MANY_REQUESTS,
                     ['content-type' => 'application/json'],
-                    json_encode(['error' => 'Too Many Requests'])
+                    json_encode(['error' => 'Too Many Requests', 'message' => 'Rate limit exceeded; try again later'])
                 );
             }
 
@@ -236,7 +257,7 @@ class ServerRoutes
                 return new Response(
                     Status::BAD_REQUEST,
                     ['content-type' => 'application/json'],
-                    json_encode(['error' => 'Bad Request'])
+                    json_encode(['error' => 'Bad Request', 'message' => 'Invalid or missing JSON fields'])
                 );
             }
 
@@ -250,14 +271,14 @@ class ServerRoutes
                 return new Response(
                     Status::UNAUTHORIZED,
                     ['content-type' => 'application/json'],
-                    json_encode(['error' => 'Invalid authorization'])
+                    json_encode(['error' => 'Unauthorized', 'message' => 'Invalid authorization'])
                 );
             } catch (SecretNotFoundException $e) {
                 $logger->error(sprintf('JSON secret %s was requested but was not found.', $secretID));
                 return new Response(
                     Status::NOT_FOUND,
                     ['content-type' => 'application/json'],
-                    json_encode(['error' => 'Not found or expired'])
+                    json_encode(['error' => 'Not Found', 'message' => 'Not found or expired'])
                 );
             }
 

--- a/server/tests/Unit/CreateRequestTest.php
+++ b/server/tests/Unit/CreateRequestTest.php
@@ -104,4 +104,79 @@ class CreateRequestTest extends TestCase
         $this->expectException(\Exception::class);
         CreateRequest::fromString("{$salt}\${$verifier}\${$secret}\$3600\$5\$extra");
     }
+
+    // -------------------------------------------------------------------------
+    // fromJson()
+    // -------------------------------------------------------------------------
+
+    private function validEncryptedSecret(): string
+    {
+        return bin2hex(str_repeat('a', 16)) . '$' . bin2hex(str_repeat('b', 32)) . '$' . bin2hex('mysecret');
+    }
+
+    public function testFromJsonParsesValidRequest(): void
+    {
+        $json = json_encode([
+            'encrypted_secret' => $this->validEncryptedSecret(),
+            'ttl'              => 3600,
+            'max_views'        => 5,
+        ]);
+
+        $request = CreateRequest::fromJson($json);
+
+        $this->assertSame(3600, $request->ttl());
+        $this->assertSame(5, $request->maxViews());
+    }
+
+    public function testFromJsonDefaultsTtlAndMaxViews(): void
+    {
+        $json = json_encode(['encrypted_secret' => $this->validEncryptedSecret()]);
+
+        $request = CreateRequest::fromJson($json);
+
+        $this->assertSame(CreateRequest::DEFAULT_TTL, $request->ttl());
+        $this->assertSame(0, $request->maxViews());
+    }
+
+    public function testFromJsonThrowsOnMissingEncryptedSecret(): void
+    {
+        $this->expectException(\Exception::class);
+        CreateRequest::fromJson(json_encode(['ttl' => 3600]));
+    }
+
+    public function testFromJsonThrowsOnInvalidJson(): void
+    {
+        $this->expectException(\Exception::class);
+        CreateRequest::fromJson('not-json');
+    }
+
+    public function testFromJsonThrowsOnInvalidTtl(): void
+    {
+        $json = json_encode([
+            'encrypted_secret' => $this->validEncryptedSecret(),
+            'ttl'              => 9999999,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        CreateRequest::fromJson($json);
+    }
+
+    public function testFromJsonThrowsOnInvalidMaxViews(): void
+    {
+        $json = json_encode([
+            'encrypted_secret' => $this->validEncryptedSecret(),
+            'max_views'        => 7,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        CreateRequest::fromJson($json);
+    }
+
+    public function testFromJsonThrowsOnWrongEncryptedSecretSegmentCount(): void
+    {
+        $json = json_encode(['encrypted_secret' => 'onlyone']);
+
+        $this->expectException(\Exception::class);
+        CreateRequest::fromJson($json);
+    }
 }

--- a/server/tests/Unit/CreateSecretJsonTest.php
+++ b/server/tests/Unit/CreateSecretJsonTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use Amp\Http\Server\Driver\Client;
+use Amp\Http\Server\Request;
+use Amp\Http\Status;
+use League\Uri\Http;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\ServerRoutes;
+
+class CreateSecretJsonTest extends TestCase
+{
+    private function makeRedisMock(): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['setex'])
+            ->getMock();
+    }
+
+    private function makeRequest(string $body): Request
+    {
+        $client = $this->createMock(Client::class);
+        $request = new Request($client, 'POST', Http::new('http://localhost/api/create'));
+        $request->setBody($body);
+        return $request;
+    }
+
+    private function validPayload(int $ttl = 3600, int $maxViews = 0): string
+    {
+        $salt     = bin2hex(str_repeat('a', 16));
+        $verifier = bin2hex(str_repeat('b', 32));
+        $secret   = bin2hex('mysecret');
+        $encrypted = "{$salt}\${$verifier}\${$secret}";
+        return json_encode(['encrypted_secret' => $encrypted, 'ttl' => $ttl, 'max_views' => $maxViews]);
+    }
+
+    public function testReturns201WithJsonOnSuccess(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->exactly(3))->method('setex');
+
+        $handler  = ServerRoutes::createSecret($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($this->validPayload())));
+
+        $this->assertSame(Status::CREATED, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+
+        $this->assertArrayHasKey('id', $parsed);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{12}$/', $parsed['id']);
+        $this->assertArrayHasKey('expires_at', $parsed);
+        $this->assertIsInt($parsed['expires_at']);
+        $this->assertGreaterThan(time(), $parsed['expires_at']);
+        $this->assertArrayHasKey('max_views', $parsed);
+        $this->assertSame(0, $parsed['max_views']);
+    }
+
+    public function testReturns201WithMaxViewsInResponse(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->exactly(4))->method('setex'); // verifier, secret, expires, views
+
+        $handler  = ServerRoutes::createSecret($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($this->validPayload(3600, 5))));
+
+        $this->assertSame(Status::CREATED, $response->getStatus());
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+
+        $this->assertSame(5, $parsed['max_views']);
+    }
+
+    public function testReturns400OnMissingEncryptedSecret(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+
+        $handler  = ServerRoutes::createSecret($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest(json_encode(['ttl' => 3600]))));
+
+        $this->assertSame(Status::BAD_REQUEST, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertSame('Bad Request', $parsed['error']);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+
+    public function testReturns400OnInvalidJson(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+
+        $handler  = ServerRoutes::createSecret($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest('not-json')));
+
+        $this->assertSame(Status::BAD_REQUEST, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertSame('Bad Request', $parsed['error']);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+
+    public function testReturns422OnInvalidTtl(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+
+        $salt     = bin2hex(str_repeat('a', 16));
+        $verifier = bin2hex(str_repeat('b', 32));
+        $secret   = bin2hex('mysecret');
+        $body     = json_encode([
+            'encrypted_secret' => "{$salt}\${$verifier}\${$secret}",
+            'ttl'              => 9999999,
+        ]);
+
+        $handler  = ServerRoutes::createSecret($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($body)));
+
+        $this->assertSame(Status::UNPROCESSABLE_ENTITY, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertSame('Unprocessable Entity', $parsed['error']);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+
+    public function testReturns422OnInvalidMaxViews(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+
+        $salt     = bin2hex(str_repeat('a', 16));
+        $verifier = bin2hex(str_repeat('b', 32));
+        $secret   = bin2hex('mysecret');
+        $body     = json_encode([
+            'encrypted_secret' => "{$salt}\${$verifier}\${$secret}",
+            'max_views'        => 7,
+        ]);
+
+        $handler  = ServerRoutes::createSecret($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($body)));
+
+        $this->assertSame(Status::UNPROCESSABLE_ENTITY, $response->getStatus());
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertSame('Unprocessable Entity', $parsed['error']);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+
+    public function testReturns413OnOversizedPayload(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+
+        $handler  = ServerRoutes::createSecret($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest(str_repeat('x', 101 * 1000))));
+
+        $this->assertSame(Status::PAYLOAD_TOO_LARGE, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertSame('Payload Too Large', $parsed['error']);
+        $this->assertArrayHasKey('message', $parsed);
+    }
+
+    public function testExpiresAtReflectsRequestedTtl(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->method('setex');
+
+        $ttl      = 7200;
+        $before   = time();
+        $handler  = ServerRoutes::createSecret($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($this->validPayload($ttl))));
+        $after    = time();
+
+        $body      = \Amp\Promise\wait($response->getBody()->read());
+        $parsed    = json_decode($body, true);
+        $expiresAt = $parsed['expires_at'];
+
+        $this->assertGreaterThanOrEqual($before + $ttl, $expiresAt);
+        $this->assertLessThanOrEqual($after + $ttl, $expiresAt);
+    }
+}

--- a/server/tests/Unit/RetrieveRateLimitTest.php
+++ b/server/tests/Unit/RetrieveRateLimitTest.php
@@ -46,7 +46,9 @@ class RetrieveRateLimitTest extends TestCase
         $this->assertSame('application/json', $response->getHeader('content-type'));
 
         $body = \Amp\Promise\wait($response->getBody()->read());
-        $this->assertSame(['error' => 'Too Many Requests'], json_decode($body, true));
+        $decoded = json_decode($body, true);
+        $this->assertSame('Too Many Requests', $decoded['error']);
+        $this->assertArrayHasKey('message', $decoded);
     }
 
     public function testReturns429AtLimitPlusOne(): void

--- a/swagger.yml
+++ b/swagger.yml
@@ -127,28 +127,76 @@ paths:
       tags:
         - "api"
       consumes:
-        - "text/plain"
+        - "application/json"
       produces:
-        - "text/plain"
+        - "application/json"
       parameters:
         - in: "body"
           name: "body"
-          description: |
-            Serialized secret to store in the server. Format: hex(salt)$hex(verifier)$hex(secret)[$ttl[$max_views]]
-            The optional TTL field specifies the secret lifetime in seconds (1–604800). Defaults to 86400.
-            The optional max_views field limits how many times the secret may be retrieved. Allowed values: 1, 3, 5, 10, or 0 (unlimited, default).
+          description: "JSON secret creation request"
           required: true
           schema:
-            type: "string"
+            type: "object"
+            required:
+              - "encrypted_secret"
+            properties:
+              encrypted_secret:
+                type: "string"
+                description: "Client-side encrypted payload: hex(salt)$hex(verifier)$hex(secret)"
+              ttl:
+                type: "integer"
+                description: "Secret lifetime in seconds (1–604800). Defaults to 86400."
+              max_views:
+                type: "integer"
+                description: "Maximum retrieval count. Allowed values: 0 (unlimited), 1, 3, 5, 10. Defaults to 0."
       responses:
         "201":
           description: "Created"
+          schema:
+            type: "object"
+            properties:
+              id:
+                type: "string"
+                description: "The generated secret ID"
+              expires_at:
+                type: "integer"
+                description: "Unix timestamp when the secret expires"
+              max_views:
+                type: "integer"
+                description: "Maximum retrieval count (0 = unlimited)"
         "400":
           description: "Bad Request"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Bad Request"
+              message:
+                type: "string"
+                example: "Invalid or missing JSON fields"
         "413":
           description: "Payload Too Large"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Payload Too Large"
+              message:
+                type: "string"
+                example: "Request body exceeds maximum allowed size"
         "422":
           description: "Unprocessable Entity — TTL out of range or invalid max_views"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Unprocessable Entity"
+              message:
+                type: "string"
+                example: "TTL must be between 1 and 604800 seconds."
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."
@@ -199,12 +247,18 @@ paths:
               error:
                 type: "string"
                 example: "Bad Request"
+              message:
+                type: "string"
+                example: "Invalid or missing JSON fields"
         "401":
           description: "Unauthorized"
           schema:
             type: "object"
             properties:
               error:
+                type: "string"
+                example: "Unauthorized"
+              message:
                 type: "string"
                 example: "Invalid authorization"
         "404":
@@ -214,4 +268,18 @@ paths:
             properties:
               error:
                 type: "string"
+                example: "Not Found"
+              message:
+                type: "string"
                 example: "Not found or expired"
+        "429":
+          description: "Too Many Requests"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Too Many Requests"
+              message:
+                type: "string"
+                example: "Rate limit exceeded; try again later"


### PR DESCRIPTION
## Summary

Resolves [DIS-882](https://linear.app/displace-tech/issue/DIS-882/switch-api-to-json-requestresponse-format)

## Changes

### `POST /api/create`
- Now accepts JSON `{encrypted_secret, ttl, max_views}` (was text/plain)
- Returns JSON `{id, expires_at, max_views}` (was plain-text ID)
- All error responses use `{error, message}` format

### `POST /api/retrieve`
- Already accepted/returned JSON — no functional change
- Error responses updated to `{error, message}` format (was `{error}` only)

### Legacy redirect routes
- `POST /create` → 308 to `/api/create` (preserved)
- `POST /retrieve` → 308 to `/api/retrieve` (preserved)

## Implementation Details

- Added `CreateRequest::fromJson()` factory method that parses `{encrypted_secret, ttl, max_views}` where `encrypted_secret` is `hex(salt)$hex(verifier)$hex(secret)`
- Updated `ServerRoutes::createSecret()` to use the new JSON parser and return JSON metadata
- Updated `ServerRoutes::retrieveSecretJson()` error responses to include both `error` and `message` fields
- Updated `swagger.yml` to document the new JSON contract for both endpoints

## Tests

- Added `CreateSecretJsonTest` (8 new tests) covering success path, error cases, and edge cases
- Added `fromJson()` unit tests to `CreateRequestTest` (7 new tests)
- Updated `RetrieveRateLimitTest` to expect `{error, message}` format
- All 64 PHP tests pass; frontend lint and tests pass