### PR TITLE
DIS-895: Add coverage collection and artifact upload to CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           php-version: '8.4'
           extensions: pcntl
-          coverage: none
+          coverage: pcov
 
       - name: Install Composer dependencies
         working-directory: server
@@ -48,10 +48,16 @@ jobs:
 
       - name: Run PHPUnit tests
         working-directory: server
-        run: composer test
+        run: composer test -- --coverage-clover coverage/clover.xml
         env:
           REDIS_HOST: 127.0.0.1
           REDIS_PORT: 6379
+
+      - name: Upload PHP coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: php-coverage
+          path: server/coverage/clover.xml
 
   js-test:
     runs-on: ubuntu-latest
@@ -73,7 +79,13 @@ jobs:
 
       - name: Run Vitest tests
         working-directory: frontend
-        run: npm test
+        run: npm test -- --coverage
+
+      - name: Upload JS coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: js-coverage
+          path: frontend/coverage/
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## DIS-895: Add test steps to CI pipeline (PHPUnit + Vitest)

References: [DIS-895](https://linear.app/displace-tech/issue/DIS-895/add-test-steps-to-ci-pipeline-phpunit-vitest)

### Changes

The CI workflow already had `test` (PHPUnit) and `js-test` (Vitest) jobs that ran both test suites and blocked the build on failure. This PR completes the acceptance criteria by adding coverage collection and artifact uploads:

**PHP (`test` job):**
- Changed `coverage: none` → `coverage: pcov` in `shivammathur/setup-php` to enable coverage instrumentation
- Added `--coverage-clover coverage/clover.xml` to the PHPUnit run command
- Added `actions/upload-artifact@v4` step to upload `server/coverage/clover.xml` as the `php-coverage` artifact

**JavaScript (`js-test` job):**
- Added `--coverage` flag to the Vitest run (coverage provider and reporters already configured in `vite.config.js` as `v8` + `lcov`/`text`)
- Added `actions/upload-artifact@v4` step to upload `frontend/coverage/` as the `js-coverage` artifact

### Acceptance Criteria
- ✅ CI runs both test suites (PHPUnit + Vitest)
- ✅ Build fails on test failure (`build` job has `needs: [test, js-test]`)
- ✅ Coverage reports available as build artifacts (`php-coverage` and `js-coverage`)