### PR TITLE
DIS-892: Fix rate limit to 10 req/min and add X-RateLimit-* headers

### DIFF
--- a/server/src/RateLimiter.php
+++ b/server/src/RateLimiter.php
@@ -6,7 +6,7 @@ use Predis\Client;
 
 class RateLimiter
 {
-    private const LIMIT = 30;
+    private const LIMIT = 10;
     private const WINDOW = 60;
 
     public function __construct(private Client $redis) {}
@@ -18,9 +18,9 @@ class RateLimiter
      * after WINDOW seconds so keys clean up automatically.
      *
      * @param string $ip Client IP address
-     * @return bool true if the request is allowed, false if the limit is exceeded
+     * @return array{allowed: bool, limit: int, remaining: int, reset: int}
      */
-    public function isAllowed(string $ip): bool
+    public function isAllowed(string $ip): array
     {
         $window = (int) floor(time() / self::WINDOW);
         $key    = "rate_limit:{$ip}:{$window}";
@@ -30,6 +30,11 @@ class RateLimiter
             $this->redis->expire($key, self::WINDOW);
         }
 
-        return $count <= self::LIMIT;
+        return [
+            'allowed'   => $count <= self::LIMIT,
+            'limit'     => self::LIMIT,
+            'remaining' => max(0, self::LIMIT - $count),
+            'reset'     => ($window + 1) * self::WINDOW,
+        ];
     }
 }

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -239,12 +239,19 @@ class ServerRoutes
         $service     = new SecretService($redisClient);
         $rateLimiter = new RateLimiter($redisClient);
         return new CallableRequestHandler(function (Request $request) use ($logger, $service, $rateLimiter) {
-            $ip = $request->getClient()->getRemoteAddress()->getHost();
-            if (!$rateLimiter->isAllowed($ip)) {
+            $ip          = $request->getClient()->getRemoteAddress()->getHost();
+            $rateLimit   = $rateLimiter->isAllowed($ip);
+            $rlHeaders   = [
+                'X-RateLimit-Limit'     => (string) $rateLimit['limit'],
+                'X-RateLimit-Remaining' => (string) $rateLimit['remaining'],
+                'X-RateLimit-Reset'     => (string) $rateLimit['reset'],
+            ];
+
+            if (!$rateLimit['allowed']) {
                 $logger->warning(sprintf('Rate limit exceeded for IP %s on /api/retrieve', $ip));
                 return new Response(
                     Status::TOO_MANY_REQUESTS,
-                    ['content-type' => 'application/json'],
+                    array_merge(['content-type' => 'application/json'], $rlHeaders),
                     json_encode(['error' => 'Too Many Requests', 'message' => 'Rate limit exceeded; try again later'])
                 );
             }
@@ -256,7 +263,7 @@ class ServerRoutes
                 $logger->error('Unable to decode JSON retrieval request');
                 return new Response(
                     Status::BAD_REQUEST,
-                    ['content-type' => 'application/json'],
+                    array_merge(['content-type' => 'application/json'], $rlHeaders),
                     json_encode(['error' => 'Bad Request', 'message' => 'Invalid or missing JSON fields'])
                 );
             }
@@ -270,14 +277,14 @@ class ServerRoutes
                 $logger->error(sprintf('JSON secret %s requested with an invalid verifier.', $secretID));
                 return new Response(
                     Status::UNAUTHORIZED,
-                    ['content-type' => 'application/json'],
+                    array_merge(['content-type' => 'application/json'], $rlHeaders),
                     json_encode(['error' => 'Unauthorized', 'message' => 'Invalid authorization'])
                 );
             } catch (SecretNotFoundException $e) {
                 $logger->error(sprintf('JSON secret %s was requested but was not found.', $secretID));
                 return new Response(
                     Status::NOT_FOUND,
-                    ['content-type' => 'application/json'],
+                    array_merge(['content-type' => 'application/json'], $rlHeaders),
                     json_encode(['error' => 'Not Found', 'message' => 'Not found or expired'])
                 );
             }
@@ -290,7 +297,7 @@ class ServerRoutes
 
             return new Response(
                 Status::OK,
-                ['content-type' => 'application/json'],
+                array_merge(['content-type' => 'application/json'], $rlHeaders),
                 json_encode($result)
             );
         });

--- a/server/tests/Unit/RateLimiterTest.php
+++ b/server/tests/Unit/RateLimiterTest.php
@@ -24,28 +24,35 @@ class RateLimiterTest extends TestCase
         $redis->method('incr')->willReturn(1);
 
         $limiter = new RateLimiter($redis);
+        $result  = $limiter->isAllowed('192.168.1.1');
 
-        $this->assertTrue($limiter->isAllowed('192.168.1.1'));
+        $this->assertTrue($result['allowed']);
+        $this->assertSame(10, $result['limit']);
+        $this->assertSame(9, $result['remaining']);
     }
 
     public function testAllowsRequestAtExactLimit(): void
     {
         $redis = $this->makeRedisMock();
-        $redis->method('incr')->willReturn(30);
+        $redis->method('incr')->willReturn(10);
 
         $limiter = new RateLimiter($redis);
+        $result  = $limiter->isAllowed('192.168.1.1');
 
-        $this->assertTrue($limiter->isAllowed('192.168.1.1'));
+        $this->assertTrue($result['allowed']);
+        $this->assertSame(0, $result['remaining']);
     }
 
     public function testDeniesRequestWhenLimitExceeded(): void
     {
         $redis = $this->makeRedisMock();
-        $redis->method('incr')->willReturn(31);
+        $redis->method('incr')->willReturn(11);
 
         $limiter = new RateLimiter($redis);
+        $result  = $limiter->isAllowed('192.168.1.1');
 
-        $this->assertFalse($limiter->isAllowed('192.168.1.1'));
+        $this->assertFalse($result['allowed']);
+        $this->assertSame(0, $result['remaining']);
     }
 
     public function testSetsExpireOnFirstRequest(): void

--- a/server/tests/Unit/RetrieveRateLimitTest.php
+++ b/server/tests/Unit/RetrieveRateLimitTest.php
@@ -37,7 +37,7 @@ class RetrieveRateLimitTest extends TestCase
     public function testReturns429WhenRateLimitExceeded(): void
     {
         $logger  = new Logger('test');
-        $redis   = $this->makeRedisMock(31);
+        $redis   = $this->makeRedisMock(11);
 
         $handler  = ServerRoutes::retrieveSecretJson($logger, $redis);
         $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
@@ -45,21 +45,26 @@ class RetrieveRateLimitTest extends TestCase
         $this->assertSame(Status::TOO_MANY_REQUESTS, $response->getStatus());
         $this->assertSame('application/json', $response->getHeader('content-type'));
 
-        $body = \Amp\Promise\wait($response->getBody()->read());
+        $body    = \Amp\Promise\wait($response->getBody()->read());
         $decoded = json_decode($body, true);
         $this->assertSame('Too Many Requests', $decoded['error']);
         $this->assertArrayHasKey('message', $decoded);
+
+        $this->assertSame('10', $response->getHeader('x-ratelimit-limit'));
+        $this->assertSame('0', $response->getHeader('x-ratelimit-remaining'));
+        $this->assertNotNull($response->getHeader('x-ratelimit-reset'));
     }
 
     public function testReturns429AtLimitPlusOne(): void
     {
         $logger  = new Logger('test');
-        $redis   = $this->makeRedisMock(31);
+        $redis   = $this->makeRedisMock(11);
 
         $handler  = ServerRoutes::retrieveSecretJson($logger, $redis);
         $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest('10.0.0.1')));
 
         $this->assertSame(Status::TOO_MANY_REQUESTS, $response->getStatus());
+        $this->assertSame('10', $response->getHeader('x-ratelimit-limit'));
     }
 
     public function testDoesNotReturn429WhenUnderLimit(): void
@@ -76,5 +81,8 @@ class RetrieveRateLimitTest extends TestCase
         $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
 
         $this->assertNotSame(Status::TOO_MANY_REQUESTS, $response->getStatus());
+        $this->assertSame('10', $response->getHeader('x-ratelimit-limit'));
+        $this->assertSame('9', $response->getHeader('x-ratelimit-remaining'));
+        $this->assertNotNull($response->getHeader('x-ratelimit-reset'));
     }
 }


### PR DESCRIPTION
## Summary

Closes DIS-892 — https://linear.app/displace-tech/issue/DIS-892/add-rate-limiting-to-retrieve-endpoint

The `POST /api/retrieve` endpoint already had IP-based rate limiting via Redis, but two acceptance criteria were not met:

1. **Rate limit was 30 req/min** — should be **10 req/min per IP**
2. **No `X-RateLimit-*` headers** were included in responses

## Changes

- `RateLimiter.php`: Lower `LIMIT` constant from 30 → 10; change `isAllowed()` return type from `bool` to a structured array containing `allowed`, `limit`, `remaining`, and `reset` fields
- `ServerRoutes.php`: Use the new return format in `retrieveSecretJson`; attach `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers to **all** responses from the endpoint (429, 400, 401, 404, and 200)
- `RateLimiterTest.php`: Update assertions to match the new array return format and the corrected limit of 10
- `RetrieveRateLimitTest.php`: Update incr values to reflect the new limit; add assertions verifying `X-RateLimit-*` headers are present and correct on both rate-limited and non-rate-limited responses

## Acceptance Criteria

- [x] Retrieve endpoint is limited to 10 requests per minute per IP
- [x] Exceeding limit returns 429
- [x] Rate limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) are included in responses

## Testing

All 64 PHP unit tests pass. Frontend tests (6) and ESLint also pass.