### PR TITLE
DIS-890: Validate TTL against allowed values

### DIFF
--- a/server/src/CreateRequest.php
+++ b/server/src/CreateRequest.php
@@ -5,7 +5,7 @@ namespace Swordfish\Server;
 class CreateRequest
 {
     const DEFAULT_TTL = 86400;
-    const MAX_TTL = 604800;
+    const ALLOWED_TTLS = [3600, 21600, 86400, 259200, 604800];
     const ALLOWED_MAX_VIEWS = [0, 1, 3, 5, 10];
 
     protected string $salt;
@@ -102,8 +102,8 @@ class CreateRequest
         $ttl = self::DEFAULT_TTL;
         if (isset($parsed['ttl'])) {
             $ttl = (int) $parsed['ttl'];
-            if ($ttl < 1 || $ttl > self::MAX_TTL) {
-                throw new \InvalidArgumentException(sprintf('TTL must be between 1 and %d seconds.', self::MAX_TTL));
+            if (!in_array($ttl, self::ALLOWED_TTLS, true)) {
+                throw new \InvalidArgumentException(sprintf('TTL must be one of: %s seconds.', implode(', ', self::ALLOWED_TTLS)));
             }
         }
 
@@ -153,8 +153,8 @@ class CreateRequest
        $ttl = self::DEFAULT_TTL;
        if (sizeof($parts) >= 4) {
            $ttl = (int) $parts[3];
-           if ($ttl < 1 || $ttl > self::MAX_TTL) {
-               throw new \InvalidArgumentException(sprintf('TTL must be between 1 and %d seconds.', self::MAX_TTL));
+           if (!in_array($ttl, self::ALLOWED_TTLS, true)) {
+               throw new \InvalidArgumentException(sprintf('TTL must be one of: %s seconds.', implode(', ', self::ALLOWED_TTLS)));
            }
        }
 

--- a/server/tests/Unit/CreateRequestTest.php
+++ b/server/tests/Unit/CreateRequestTest.php
@@ -105,6 +105,29 @@ class CreateRequestTest extends TestCase
         CreateRequest::fromString("{$salt}\${$verifier}\${$secret}\$3600\$5\$extra");
     }
 
+    public function testFromStringRejectsDisallowedTtlValue(): void
+    {
+        $salt     = bin2hex(str_repeat('a', 16));
+        $verifier = bin2hex(str_repeat('b', 32));
+        $secret   = bin2hex('mysecret');
+
+        $this->expectException(\InvalidArgumentException::class);
+        CreateRequest::fromString("{$salt}\${$verifier}\${$secret}\$7200");
+    }
+
+    /**
+     * @dataProvider allowedTtlProvider
+     */
+    public function testFromStringAcceptsAllowedTtlValues(int $ttl): void
+    {
+        $salt     = bin2hex(str_repeat('a', 16));
+        $verifier = bin2hex(str_repeat('b', 32));
+        $secret   = bin2hex('mysecret');
+
+        $request = CreateRequest::fromString("{$salt}\${$verifier}\${$secret}\${$ttl}");
+        $this->assertSame($ttl, $request->ttl());
+    }
+
     // -------------------------------------------------------------------------
     // fromJson()
     // -------------------------------------------------------------------------
@@ -148,6 +171,44 @@ class CreateRequestTest extends TestCase
     {
         $this->expectException(\Exception::class);
         CreateRequest::fromJson('not-json');
+    }
+
+    /**
+     * @dataProvider allowedTtlProvider
+     */
+    public function testFromJsonAcceptsAllowedTtlValues(int $ttl): void
+    {
+        $json = json_encode([
+            'encrypted_secret' => $this->validEncryptedSecret(),
+            'ttl'              => $ttl,
+        ]);
+
+        $request = CreateRequest::fromJson($json);
+        $this->assertSame($ttl, $request->ttl());
+    }
+
+    public static function allowedTtlProvider(): array
+    {
+        return [[3600], [21600], [86400], [259200], [604800]];
+    }
+
+    /**
+     * @dataProvider disallowedTtlProvider
+     */
+    public function testFromJsonThrowsOnDisallowedTtlValue(int $ttl): void
+    {
+        $json = json_encode([
+            'encrypted_secret' => $this->validEncryptedSecret(),
+            'ttl'              => $ttl,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        CreateRequest::fromJson($json);
+    }
+
+    public static function disallowedTtlProvider(): array
+    {
+        return [[1], [1800], [7200], [43200], [9999999]];
     }
 
     public function testFromJsonThrowsOnInvalidTtl(): void

--- a/server/tests/Unit/CreateSecretJsonTest.php
+++ b/server/tests/Unit/CreateSecretJsonTest.php
@@ -187,7 +187,7 @@ class CreateSecretJsonTest extends TestCase
         $redis  = $this->makeRedisMock();
         $redis->method('setex');
 
-        $ttl      = 7200;
+        $ttl      = 21600;
         $before   = time();
         $handler  = ServerRoutes::createSecret($logger, $redis);
         $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($this->validPayload($ttl))));
@@ -199,5 +199,21 @@ class CreateSecretJsonTest extends TestCase
 
         $this->assertGreaterThanOrEqual($before + $ttl, $expiresAt);
         $this->assertLessThanOrEqual($after + $ttl, $expiresAt);
+    }
+
+    public function testReturns422OnDisallowedTtlValue(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+
+        $handler  = ServerRoutes::createSecret($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest($this->validPayload(7200))));
+
+        $this->assertSame(Status::UNPROCESSABLE_ENTITY, $response->getStatus());
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertSame('Unprocessable Entity', $parsed['error']);
+        $this->assertStringContainsString('TTL must be one of', $parsed['message']);
     }
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -145,7 +145,7 @@ paths:
                 description: "Client-side encrypted payload: hex(salt)$hex(verifier)$hex(secret)"
               ttl:
                 type: "integer"
-                description: "Secret lifetime in seconds (1–604800). Defaults to 86400."
+                description: "Secret lifetime in seconds. Allowed values: 3600, 21600, 86400, 259200, 604800. Defaults to 86400."
               max_views:
                 type: "integer"
                 description: "Maximum retrieval count. Allowed values: 0 (unlimited), 1, 3, 5, 10. Defaults to 0."
@@ -187,7 +187,7 @@ paths:
                 type: "string"
                 example: "Request body exceeds maximum allowed size"
         "422":
-          description: "Unprocessable Entity — TTL out of range or invalid max_views"
+          description: "Unprocessable Entity — disallowed TTL value or invalid max_views"
           schema:
             type: "object"
             properties:
@@ -196,7 +196,7 @@ paths:
                 example: "Unprocessable Entity"
               message:
                 type: "string"
-                example: "TTL must be between 1 and 604800 seconds."
+                example: "TTL must be one of: 3600, 21600, 86400, 259200, 604800 seconds."
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."


### PR DESCRIPTION
## DIS-890 — Implement configurable expiration (TTL)

Linear: https://linear.app/displace-tech/issue/DIS-890/implement-configurable-expiration-ttl

### What changed

The TTL parameter on `POST /api/create` was previously validated against an open-ended range (1–604800 seconds). This PR tightens that to an explicit allowlist matching the ticket spec:

**Allowed values:** `3600`, `21600`, `86400`, `259200`, `604800` (seconds)

### Changes

- **`server/src/CreateRequest.php`** — Replace `MAX_TTL` constant with `ALLOWED_TTLS = [3600, 21600, 86400, 259200, 604800]`; update `fromJson()` and `fromString()` to use `in_array()` validation with a descriptive error message listing the permitted values.
- **`server/tests/Unit/CreateRequestTest.php`** — Add `@dataProvider` tests covering every allowed TTL value and several disallowed-but-in-range values for both `fromJson()` and `fromString()`.
- **`server/tests/Unit/CreateSecretJsonTest.php`** — Add handler-level test asserting a disallowed TTL (7200) returns 422; fix `testExpiresAtReflectsRequestedTtl` to use an allowed value (21600).
- **`swagger.yml`** — Update TTL field description and 422 example message to reflect the allowlist.

### Acceptance criteria

- [x] Secrets are stored with the requested TTL (unchanged — `SecretService` already applied TTL correctly)
- [x] Invalid TTL values are rejected with a 422 error
- [x] Default TTL is 86400 (unchanged)
- [x] The verifier key still expires 30 s before the secret key (unchanged)

### Tests

81 unit tests pass (up from 64 before this PR).