### PR TITLE
DIS-891: Implement hourly Redis metrics tracking for create/retrieve

### DIFF
--- a/server/server.php
+++ b/server/server.php
@@ -33,6 +33,7 @@ Amp\Loop::run(function () {
         'host'   => getenv('REDIS_HOST'),
         'port'   => getenv('REDIS_PORT')
     ]);
+    $metrics = new Swordfish\Server\MetricsService($redisClient);
 
     $documentRoot = new DocumentRoot(__DIR__ . '/static');
     $router = new Router();
@@ -50,9 +51,9 @@ Amp\Loop::run(function () {
     /**  Server back-end API                                  **/
     /***********************************************************/
 
-    $router->addRoute('POST', '/api/create', ServerRoutes::createSecret($logger, $redisClient));
+    $router->addRoute('POST', '/api/create', ServerRoutes::createSecret($logger, $redisClient, $metrics));
     $router->addRoute('POST', '/create', ServerRoutes::redirectCreate($logger));
-    $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecretJson($logger, $redisClient));
+    $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecretJson($logger, $redisClient, $metrics));
     $router->addRoute('POST', '/retrieve', ServerRoutes::redirectRetrieve($logger));
 
     $router->setFallback(ServerRoutes::spaFallback($logger, $documentRoot));

--- a/server/src/MetricsService.php
+++ b/server/src/MetricsService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Swordfish\Server;
+
+use Predis\Client;
+
+class MetricsService
+{
+    private const TTL = 90 * 24 * 3600; // 90 days
+
+    public function __construct(private Client $redis) {}
+
+    private function hourKey(): string
+    {
+        return date('Y-m-d:H');
+    }
+
+    /**
+     * Record a secret creation event: increment the created counter and bytes stored.
+     *
+     * @param int $bytes Number of bytes in the stored secret payload
+     */
+    public function recordCreated(int $bytes): void
+    {
+        $hour = $this->hourKey();
+
+        $this->redis->incrby("metrics:created:{$hour}", 1);
+        $this->redis->expire("metrics:created:{$hour}", self::TTL);
+        $this->redis->incrby("metrics:bytes_stored:{$hour}", $bytes);
+        $this->redis->expire("metrics:bytes_stored:{$hour}", self::TTL);
+    }
+
+    /**
+     * Record a secret retrieval event: increment the retrieved counter and bytes retrieved.
+     *
+     * @param int $bytes Number of bytes in the retrieved secret payload
+     */
+    public function recordRetrieved(int $bytes): void
+    {
+        $hour = $this->hourKey();
+
+        $this->redis->incrby("metrics:retrieved:{$hour}", 1);
+        $this->redis->expire("metrics:retrieved:{$hour}", self::TTL);
+        $this->redis->incrby("metrics:bytes_retrieved:{$hour}", $bytes);
+        $this->redis->expire("metrics:bytes_retrieved:{$hour}", self::TTL);
+    }
+}

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -107,12 +107,13 @@ class ServerRoutes
      *
      * @param Logger $logger
      * @param Client $redisClient
+     * @param MetricsService|null $metrics
      * @return CallableRequestHandler
      */
-    public static function createSecret(Logger $logger, Client $redisClient): CallableRequestHandler
+    public static function createSecret(Logger $logger, Client $redisClient, ?MetricsService $metrics = null): CallableRequestHandler
     {
         $service = new SecretService($redisClient);
-        return new CallableRequestHandler(function(Request $request) use ($logger, $service) {
+        return new CallableRequestHandler(function(Request $request) use ($logger, $service, $metrics) {
             $data = yield $request->getBody()->read();
             if (strlen($data) > 100 * 1000) {
                 $logger->error('Message payload too large!');
@@ -145,6 +146,8 @@ class ServerRoutes
             $expiresAt = time() + $secretRequest->ttl();
             $maxViews  = $secretRequest->maxViews();
             $logger->info(sprintf('Created JSON secret %s', $secretID));
+
+            $metrics?->recordCreated(strlen($secretRequest->secret()));
 
             return new Response(
                 Status::CREATED,
@@ -232,13 +235,14 @@ class ServerRoutes
      *
      * @param Logger $logger
      * @param Client $redisClient
+     * @param MetricsService|null $metrics
      * @return CallableRequestHandler
      */
-    public static function retrieveSecretJson(Logger $logger, Client $redisClient): CallableRequestHandler
+    public static function retrieveSecretJson(Logger $logger, Client $redisClient, ?MetricsService $metrics = null): CallableRequestHandler
     {
         $service     = new SecretService($redisClient);
         $rateLimiter = new RateLimiter($redisClient);
-        return new CallableRequestHandler(function (Request $request) use ($logger, $service, $rateLimiter) {
+        return new CallableRequestHandler(function (Request $request) use ($logger, $service, $rateLimiter, $metrics) {
             $ip          = $request->getClient()->getRemoteAddress()->getHost();
             $rateLimit   = $rateLimiter->isAllowed($ip);
             $rlHeaders   = [
@@ -294,6 +298,8 @@ class ServerRoutes
             }
 
             $logger->info(sprintf('Retrieved JSON secret %s (%d views remaining).', $secretID, $result['views_remaining']));
+
+            $metrics?->recordRetrieved(strlen($result['encrypted_secret']));
 
             return new Response(
                 Status::OK,

--- a/server/tests/Unit/MetricsServiceTest.php
+++ b/server/tests/Unit/MetricsServiceTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\MetricsService;
+
+class MetricsServiceTest extends TestCase
+{
+    private function makeRedisMock(): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['incrby', 'expire'])
+            ->getMock();
+    }
+
+    // -------------------------------------------------------------------------
+    // recordCreated()
+    // -------------------------------------------------------------------------
+
+    public function testRecordCreatedIncrementsCreatedCounter(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->method('incrby')
+            ->willReturnCallback(function (string $key, int $amount) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'amount' => $amount];
+                return $amount; // first call returns the amount (new key)
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordCreated(100);
+
+        $keys = array_column($capturedCalls, 'key');
+        $this->assertCount(2, $capturedCalls);
+
+        $createdKey = array_values(array_filter($keys, fn($k) => str_starts_with($k, 'metrics:created:')));
+        $bytesKey   = array_values(array_filter($keys, fn($k) => str_starts_with($k, 'metrics:bytes_stored:')));
+
+        $this->assertCount(1, $createdKey);
+        $this->assertCount(1, $bytesKey);
+    }
+
+    public function testRecordCreatedUsesIncrbyWithCorrectAmounts(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->method('incrby')
+            ->willReturnCallback(function (string $key, int $amount) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'amount' => $amount];
+                return $amount;
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordCreated(512);
+
+        $createdCall = array_values(array_filter($capturedCalls, fn($c) => str_starts_with($c['key'], 'metrics:created:')));
+        $bytesCall   = array_values(array_filter($capturedCalls, fn($c) => str_starts_with($c['key'], 'metrics:bytes_stored:')));
+
+        $this->assertSame(1, $createdCall[0]['amount']);
+        $this->assertSame(512, $bytesCall[0]['amount']);
+    }
+
+    public function testRecordCreatedSetsExpiry(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $expireCalls = [];
+        $redis->expects($this->exactly(2))
+            ->method('expire')
+            ->willReturnCallback(function (string $key, int $ttl) use (&$expireCalls) {
+                $expireCalls[] = ['key' => $key, 'ttl' => $ttl];
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordCreated(100);
+
+        $this->assertCount(2, $expireCalls);
+        foreach ($expireCalls as $call) {
+            $this->assertSame(90 * 24 * 3600, $call['ttl']);
+        }
+    }
+
+    public function testRecordCreatedKeyUsesHourlyGranularity(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedKeys = [];
+        $redis->method('incrby')
+            ->willReturnCallback(function (string $key, int $amount) use (&$capturedKeys) {
+                $capturedKeys[] = $key;
+                return $amount;
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordCreated(10);
+
+        $expectedHour = date('Y-m-d:H');
+        foreach ($capturedKeys as $key) {
+            $this->assertStringContainsString($expectedHour, $key);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // recordRetrieved()
+    // -------------------------------------------------------------------------
+
+    public function testRecordRetrievedIncrementsRetrievedCounter(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->method('incrby')
+            ->willReturnCallback(function (string $key, int $amount) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'amount' => $amount];
+                return $amount;
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordRetrieved(200);
+
+        $keys = array_column($capturedCalls, 'key');
+        $this->assertCount(2, $capturedCalls);
+
+        $retrievedKey = array_values(array_filter($keys, fn($k) => str_starts_with($k, 'metrics:retrieved:')));
+        $bytesKey     = array_values(array_filter($keys, fn($k) => str_starts_with($k, 'metrics:bytes_retrieved:')));
+
+        $this->assertCount(1, $retrievedKey);
+        $this->assertCount(1, $bytesKey);
+    }
+
+    public function testRecordRetrievedUsesIncrbyWithCorrectAmounts(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedCalls = [];
+        $redis->method('incrby')
+            ->willReturnCallback(function (string $key, int $amount) use (&$capturedCalls) {
+                $capturedCalls[] = ['key' => $key, 'amount' => $amount];
+                return $amount;
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordRetrieved(1024);
+
+        $retrievedCall = array_values(array_filter($capturedCalls, fn($c) => str_starts_with($c['key'], 'metrics:retrieved:')));
+        $bytesCall     = array_values(array_filter($capturedCalls, fn($c) => str_starts_with($c['key'], 'metrics:bytes_retrieved:')));
+
+        $this->assertSame(1, $retrievedCall[0]['amount']);
+        $this->assertSame(1024, $bytesCall[0]['amount']);
+    }
+
+    public function testRecordRetrievedSetsExpiry(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $expireCalls = [];
+        $redis->expects($this->exactly(2))
+            ->method('expire')
+            ->willReturnCallback(function (string $key, int $ttl) use (&$expireCalls) {
+                $expireCalls[] = ['key' => $key, 'ttl' => $ttl];
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordRetrieved(200);
+
+        $this->assertCount(2, $expireCalls);
+        foreach ($expireCalls as $call) {
+            $this->assertSame(90 * 24 * 3600, $call['ttl']);
+        }
+    }
+
+    public function testRecordRetrievedKeyUsesHourlyGranularity(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $capturedKeys = [];
+        $redis->method('incrby')
+            ->willReturnCallback(function (string $key, int $amount) use (&$capturedKeys) {
+                $capturedKeys[] = $key;
+                return $amount;
+            });
+
+        $service = new MetricsService($redis);
+        $service->recordRetrieved(10);
+
+        $expectedHour = date('Y-m-d:H');
+        foreach ($capturedKeys as $key) {
+            $this->assertStringContainsString($expectedHour, $key);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements usage metrics tracking in Redis as described in [DIS-891](https://linear.app/displace-tech/issue/DIS-891/implement-usage-metrics-tracking-in-redis).

## Changes

- **`server/src/MetricsService.php`** — New service class with `recordCreated(int $bytes)` and `recordRetrieved(int $bytes)` methods. Uses Redis `INCRBY` for atomic increments and `EXPIRE` to enforce a 90-day TTL on all keys.
- **`server/src/ServerRoutes.php`** — `createSecret()` and `retrieveSecretJson()` factory methods accept an optional `MetricsService` parameter. Metrics are recorded after each successful create or retrieve operation.
- **`server/server.php`** — Instantiates `MetricsService` and passes it to the two route handlers.
- **`server/tests/Unit/MetricsServiceTest.php`** — Unit tests covering counter increments, byte tracking, TTL enforcement, and hourly key granularity.

## Redis Key Schema

| Key | Incremented by |
|---|---|
| `metrics:created:YYYY-MM-DD:HH` | 1 per secret created |
| `metrics:bytes_stored:YYYY-MM-DD:HH` | byte length of stored payload |
| `metrics:retrieved:YYYY-MM-DD:HH` | 1 per secret retrieved |
| `metrics:bytes_retrieved:YYYY-MM-DD:HH` | byte length of retrieved payload |

All keys expire after **90 days** (7,776,000 seconds).

## Acceptance Criteria

- [x] Creating a secret increments the created counter
- [x] Retrieving a secret increments the retrieved counter
- [x] Byte sizes are tracked for both operations
- [x] Keys use hourly granularity with 90-day TTL
- [x] All tests pass