### PR TITLE
DIS-893: Implement atomic Lua script for race-condition-safe view limits

### DIFF
--- a/server/src/SecretService.php
+++ b/server/src/SecretService.php
@@ -6,6 +6,49 @@ use Predis\Client;
 
 class SecretService
 {
+    /**
+     * Atomic Lua script for view-limited secret retrieval.
+     *
+     * KEYS: [1]=viewsKey, [2]=secretKey, [3]=verifierKey, [4]=expiresKey
+     *
+     * Returns a three-element array:
+     *   [0] encrypted_secret (string) or nil when not found / views exhausted
+     *   [1] expires_at timestamp string or nil
+     *   [2] views_remaining as a string, or false (nil) for unlimited secrets
+     *
+     * The entire read-decrement-delete sequence executes atomically, preventing
+     * two concurrent requests from both retrieving the last available view.
+     */
+    private const LUA_RETRIEVE = <<<'LUA'
+local viewsKey    = KEYS[1]
+local secretKey   = KEYS[2]
+local verifierKey = KEYS[3]
+local expiresKey  = KEYS[4]
+
+local views = redis.call('GET', viewsKey)
+
+if views == false then
+    local secret  = redis.call('GET', secretKey)
+    local expires = redis.call('GET', expiresKey)
+    return {secret, expires, false}
+end
+
+local newViews = redis.call('DECR', viewsKey)
+
+if newViews < 0 then
+    return {false, false, false}
+end
+
+local secret  = redis.call('GET', secretKey)
+local expires = redis.call('GET', expiresKey)
+
+if newViews == 0 then
+    redis.call('DEL', secretKey, verifierKey, viewsKey, expiresKey)
+end
+
+return {secret, expires, tostring(newViews)}
+LUA;
+
     public function __construct(private Client $redis) {}
 
     /**
@@ -124,24 +167,16 @@ class SecretService
             throw new InvalidVerifierException(sprintf('Invalid verifier for JSON secret %s.', $secretID));
         }
 
-        $encryptedSecret = $this->redis->get($secretKey);
+        /** @var array{0: string|null, 1: string|null, 2: string|null} $result */
+        $result = $this->redis->eval(self::LUA_RETRIEVE, 4, $viewsKey, $secretKey, $verifierKey, $expiresKey);
+
+        $encryptedSecret = $result[0] ?? null;
         if ($encryptedSecret === null) {
-            throw new SecretNotFoundException(sprintf('JSON secret %s not found.', $secretID));
+            throw new SecretNotFoundException(sprintf('JSON secret %s not found or views exhausted.', $secretID));
         }
 
-        $expiresAt = (int) $this->redis->get($expiresKey);
-
-        $viewsRaw = $this->redis->get($viewsKey);
-        if ($viewsRaw === null) {
-            // Unlimited views — no counter to decrement
-            $viewsRemaining = null;
-        } else {
-            $viewsAfter = (int) $this->redis->decr($viewsKey);
-            if ($viewsAfter <= 0) {
-                $this->redis->del($secretKey, $verifierKey, $viewsKey, $expiresKey);
-            }
-            $viewsRemaining = max(0, $viewsAfter);
-        }
+        $expiresAt      = (int) ($result[1] ?? 0);
+        $viewsRemaining = isset($result[2]) ? max(0, (int) $result[2]) : null;
 
         return [
             'encrypted_secret' => $encryptedSecret,

--- a/server/tests/Unit/SecretServiceTest.php
+++ b/server/tests/Unit/SecretServiceTest.php
@@ -17,7 +17,7 @@ class SecretServiceTest extends TestCase
     {
         return $this->getMockBuilder(RedisClient::class)
             ->disableOriginalConstructor()
-            ->addMethods(['setex', 'get', 'decr', 'del'])
+            ->addMethods(['setex', 'get', 'eval'])
             ->getMock();
     }
 
@@ -194,6 +194,9 @@ class SecretServiceTest extends TestCase
                 return null;
             });
 
+        // Lua script returns null secret (key missing or views exhausted)
+        $redis->method('eval')->willReturn([null, null, null]);
+
         $service = new SecretService($redis);
 
         $this->expectException(SecretNotFoundException::class);
@@ -211,23 +214,13 @@ class SecretServiceTest extends TestCase
                 if (str_starts_with($key, 'json_verifier:')) {
                     return $hash;
                 }
-                if (str_starts_with($key, 'json_secret:')) {
-                    return 'encrypted-payload';
-                }
-                if (str_starts_with($key, 'json_expires:')) {
-                    return '9999999999';
-                }
-                if (str_starts_with($key, 'json_views:')) {
-                    return '3'; // limited: 3 views remaining before this retrieval
-                }
                 return null;
             });
 
+        // Lua script atomically decrements and returns [secret, expires, views_remaining]
         $redis->expects($this->once())
-            ->method('decr')
-            ->willReturn(2); // 2 views remaining after decrement
-
-        $redis->expects($this->never())->method('del');
+            ->method('eval')
+            ->willReturn(['encrypted-payload', '9999999999', '2']);
 
         $service = new SecretService($redis);
         $result  = $service->retrieveJson('abc123def456', $verifier);
@@ -248,21 +241,13 @@ class SecretServiceTest extends TestCase
                 if (str_starts_with($key, 'json_verifier:')) {
                     return $hash;
                 }
-                if (str_starts_with($key, 'json_secret:')) {
-                    return 'encrypted-payload';
-                }
-                if (str_starts_with($key, 'json_expires:')) {
-                    return '9999999999';
-                }
-                if (str_starts_with($key, 'json_views:')) {
-                    return '1'; // last view
-                }
                 return null;
             });
 
-        $redis->method('decr')->willReturn(0);
-
-        $redis->expects($this->once())->method('del');
+        // Lua script returns views_remaining=0 and handles deletion internally
+        $redis->expects($this->once())
+            ->method('eval')
+            ->willReturn(['encrypted-payload', '9999999999', '0']);
 
         $service = new SecretService($redis);
         $result  = $service->retrieveJson('abc123def456', $verifier);
@@ -281,17 +266,13 @@ class SecretServiceTest extends TestCase
                 if (str_starts_with($key, 'json_verifier:')) {
                     return $hash;
                 }
-                if (str_starts_with($key, 'json_secret:')) {
-                    return 'encrypted-payload';
-                }
-                if (str_starts_with($key, 'json_expires:')) {
-                    return '9999999999';
-                }
-                return null; // no views key → unlimited
+                return null;
             });
 
-        $redis->expects($this->never())->method('decr');
-        $redis->expects($this->never())->method('del');
+        // Lua script returns null for views_remaining when no views key exists (unlimited)
+        $redis->expects($this->once())
+            ->method('eval')
+            ->willReturn(['encrypted-payload', '9999999999', null]);
 
         $service = new SecretService($redis);
         $result  = $service->retrieveJson('abc123def456', $verifier);
@@ -299,6 +280,31 @@ class SecretServiceTest extends TestCase
         $this->assertSame('encrypted-payload', $result['encrypted_secret']);
         $this->assertNull($result['views_remaining']);
         $this->assertSame(9999999999, $result['expires_at']);
+    }
+
+    public function testRetrieveJsonThrowsSecretNotFoundWhenViewsAlreadyExhausted(): void
+    {
+        $redis    = $this->makeRedisMock();
+        $verifier = 'my-verifier';
+        $hash     = password_hash($verifier, PASSWORD_DEFAULT);
+
+        $redis->method('get')
+            ->willReturnCallback(function (string $key) use ($hash) {
+                if (str_starts_with($key, 'json_verifier:')) {
+                    return $hash;
+                }
+                return null;
+            });
+
+        // Lua script returns null secret when views counter went negative (race condition)
+        $redis->expects($this->once())
+            ->method('eval')
+            ->willReturn([null, null, null]);
+
+        $service = new SecretService($redis);
+
+        $this->expectException(SecretNotFoundException::class);
+        $service->retrieveJson('abc123def456', $verifier);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## DIS-893: Implement configurable view limits — race condition fix

Linear: https://linear.app/displace-tech/issue/DIS-893/implement-configurable-view-limits

### Summary

The basic view-limit infrastructure (Redis `json_views:{id}` key, `max_views` on create, `views_remaining` in retrieve response) was already in place from a prior ticket. This PR addresses the remaining acceptance criterion:

> Race conditions handled via Redis WATCH/MULTI or **atomic Lua script**.

The previous `retrieveJson()` implementation used a non-atomic `GET → DECR → DEL` sequence. Two concurrent requests for a secret with one view remaining could both pass the counter check and both successfully retrieve the secret.

### Changes

**`server/src/SecretService.php`**
- Added `LUA_RETRIEVE` constant: a Redis Lua script that atomically checks the views counter, decrements it, reads the secret, and deletes all four keys (`json_secret`, `json_verifier`, `json_views`, `json_expires`) when views reach zero.
- `retrieveJson()` now calls `eval(LUA_RETRIEVE, ...)` after the bcrypt verifier check. If the Lua script returns a null secret (counter went negative — another request already consumed the last view), `SecretNotFoundException` is thrown.

**`server/tests/Unit/SecretServiceTest.php`**
- Updated `retrieveJson` tests to mock `eval()` instead of `get()`/`decr()`/`del()`.
- Added `testRetrieveJsonThrowsSecretNotFoundWhenViewsAlreadyExhausted` to cover the race-condition path.

### Acceptance criteria

| Criterion | Status |
|---|---|
| View-limited secrets deleted after max views reached | ✅ (Lua script calls `DEL` when `newViews == 0`) |
| Unlimited secrets behave as before | ✅ (no views key → script returns secret without touching counter) |
| `views_remaining` returned in retrieve response | ✅ |
| Race conditions handled via atomic Lua script | ✅ (entire read-decrement-delete is one atomic Redis operation) |

### Tests

```
Tests: 65, Assertions: 153 — all passing
```