### PR TITLE
DIS-904: Add --ttl flag to CLI secret:create

### DIFF
--- a/cli/src/CreateSecretCommand.php
+++ b/cli/src/CreateSecretCommand.php
@@ -4,23 +4,44 @@ namespace Swordfish\CLI;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateSecretCommand extends Command
 {
     protected static $defaultName = 'secret:create';
 
+    private const TTL_MAP = [
+        '1h'  => 3600,
+        '6h'  => 21600,
+        '24h' => 86400,
+        '3d'  => 259200,
+        '7d'  => 604800,
+    ];
+
     protected function configure()
     {
         $this->setDescription('Creates an encrypted secret on the server.')
             ->setHelp('This command allows you to create a secret, fully encrypted on the server.')
             ->addArgument('secret', InputArgument::REQUIRED, 'Plaintext secret to protect.')
-            ->addArgument('password', InputArgument::REQUIRED, 'User-friendly password used to protect the secret.');
+            ->addArgument('password', InputArgument::REQUIRED, 'User-friendly password used to protect the secret.')
+            ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time-to-live for the secret (1h, 6h, 24h, 3d, 7d).', '24h');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $serverUrl = getenv('SWORDFISH_URL') ?: 'https://swordfish.displace.tech';
+
+        $ttlString = $input->getOption('ttl');
+        if (!array_key_exists($ttlString, self::TTL_MAP)) {
+            $output->writeln(sprintf(
+                'Invalid TTL "%s". Allowed values: %s.',
+                $ttlString,
+                implode(', ', array_keys(self::TTL_MAP))
+            ));
+            return Command::FAILURE;
+        }
+        $ttl = self::TTL_MAP[$ttlString];
 
         $password = $input->getArgument('password');
         $secret = $input->getArgument('secret');
@@ -36,7 +57,7 @@ class CreateSecretCommand extends Command
 
         $encryptedSecret = bin2hex($salt) . '$' . $verifier . '$' . $encrypted;
 
-        $response = $this->httpPost("{$serverUrl}/api/create", ['encrypted_secret' => $encryptedSecret]);
+        $response = $this->httpPost("{$serverUrl}/api/create", ['encrypted_secret' => $encryptedSecret, 'ttl' => $ttl]);
 
         if ($response === false) {
             $output->writeln('Network error: could not reach server');

--- a/cli/tests/CreateSecretCommandTest.php
+++ b/cli/tests/CreateSecretCommandTest.php
@@ -76,4 +76,66 @@ class CreateSecretCommandTest extends TestCase
         $this->assertSame(Command::FAILURE, $status);
         $this->assertStringContainsString('Network error', $tester->getDisplay());
     }
+
+    public function testDefaultTtlIs24h(): void
+    {
+        $capturedData = null;
+        $command = new class($capturedData) extends CreateSecretCommand {
+            public function __construct(private mixed &$captured) {
+                parent::__construct();
+            }
+            protected function httpPost(string $url, array $data): string|false {
+                $this->captured = $data;
+                return json_encode(['id' => 'abc123']);
+            }
+        };
+        $tester = new CommandTester($command);
+        $status = $tester->execute(['secret' => 'my secret', 'password' => 'pass']);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertSame(86400, $capturedData['ttl']);
+    }
+
+    /**
+     * @dataProvider validTtlProvider
+     */
+    public function testValidTtlValues(string $ttlString, int $expectedSeconds): void
+    {
+        $capturedData = null;
+        $command = new class($capturedData) extends CreateSecretCommand {
+            public function __construct(private mixed &$captured) {
+                parent::__construct();
+            }
+            protected function httpPost(string $url, array $data): string|false {
+                $this->captured = $data;
+                return json_encode(['id' => 'abc123']);
+            }
+        };
+        $tester = new CommandTester($command);
+        $status = $tester->execute(['secret' => 'my secret', 'password' => 'pass', '--ttl' => $ttlString]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertSame($expectedSeconds, $capturedData['ttl']);
+    }
+
+    public static function validTtlProvider(): array
+    {
+        return [
+            '1h'  => ['1h',  3600],
+            '6h'  => ['6h',  21600],
+            '24h' => ['24h', 86400],
+            '3d'  => ['3d',  259200],
+            '7d'  => ['7d',  604800],
+        ];
+    }
+
+    public function testInvalidTtlShowsError(): void
+    {
+        $tester = $this->makeCommand(json_encode(['id' => 'abc123']));
+        $status = $tester->execute(['secret' => 'my secret', 'password' => 'pass', '--ttl' => '2h']);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertStringContainsString('Invalid TTL "2h"', $tester->getDisplay());
+        $this->assertStringContainsString('1h, 6h, 24h, 3d, 7d', $tester->getDisplay());
+    }
 }


### PR DESCRIPTION
## Summary

Adds a `--ttl` option to the `secret:create` CLI command, allowing users to control how long a secret lives on the server.

## Changes

- Added `--ttl` option to `CreateSecretCommand` accepting duration strings: `1h`, `6h`, `24h`, `3d`, `7d`
- Duration strings are parsed and converted to seconds before being sent in the API request payload
- Default TTL is `24h` (86400 seconds), matching the server default
- Invalid duration strings produce a helpful error message listing the allowed values
- Added tests covering all valid TTL values, the default, and invalid input

## Acceptance Criteria

- [x] `--ttl` flag works with all allowed duration strings (`1h`, `6h`, `24h`, `3d`, `7d`)
- [x] Invalid durations show a helpful error
- [x] Default is `24h`

Closes DIS-904: https://linear.app/displace-tech/issue/DIS-904/add-ttl-flag-to-cli-secretcreate