### PR TITLE
DIS-903: Add --max-views flag to CLI secret:create

### DIFF
--- a/cli/src/CreateSecretCommand.php
+++ b/cli/src/CreateSecretCommand.php
@@ -19,13 +19,16 @@ class CreateSecretCommand extends Command
         '7d'  => 604800,
     ];
 
+    private const ALLOWED_MAX_VIEWS = [1, 3, 5, 10];
+
     protected function configure()
     {
         $this->setDescription('Creates an encrypted secret on the server.')
             ->setHelp('This command allows you to create a secret, fully encrypted on the server.')
             ->addArgument('secret', InputArgument::REQUIRED, 'Plaintext secret to protect.')
             ->addArgument('password', InputArgument::REQUIRED, 'User-friendly password used to protect the secret.')
-            ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time-to-live for the secret (1h, 6h, 24h, 3d, 7d).', '24h');
+            ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time-to-live for the secret (1h, 6h, 24h, 3d, 7d).', '24h')
+            ->addOption('max-views', null, InputOption::VALUE_REQUIRED, 'Maximum number of times the secret can be viewed (1, 3, 5, 10, or unlimited).', 'unlimited');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -43,6 +46,16 @@ class CreateSecretCommand extends Command
         }
         $ttl = self::TTL_MAP[$ttlString];
 
+        $maxViewsRaw = $input->getOption('max-views');
+        if ($maxViewsRaw === 'unlimited') {
+            $maxViews = 0;
+        } elseif (in_array((int) $maxViewsRaw, self::ALLOWED_MAX_VIEWS, true) && (string)(int)$maxViewsRaw === (string)$maxViewsRaw) {
+            $maxViews = (int) $maxViewsRaw;
+        } else {
+            $output->writeln('<error>--max-views must be one of: 1, 3, 5, 10, or unlimited.</error>');
+            return Command::FAILURE;
+        }
+
         $password = $input->getArgument('password');
         $secret = $input->getArgument('secret');
         $salt = random_bytes(16);
@@ -57,7 +70,7 @@ class CreateSecretCommand extends Command
 
         $encryptedSecret = bin2hex($salt) . '$' . $verifier . '$' . $encrypted;
 
-        $response = $this->httpPost("{$serverUrl}/api/create", ['encrypted_secret' => $encryptedSecret, 'ttl' => $ttl]);
+        $response = $this->httpPost("{$serverUrl}/api/create", ['encrypted_secret' => $encryptedSecret, 'ttl' => $ttl, 'max_views' => $maxViews]);
 
         if ($response === false) {
             $output->writeln('<error>Network error: could not reach server</error>');

--- a/cli/tests/CreateSecretCommandTest.php
+++ b/cli/tests/CreateSecretCommandTest.php
@@ -77,23 +77,25 @@ class CreateSecretCommandTest extends TestCase
         $this->assertStringContainsString('Network error', $tester->getDisplay());
     }
 
-    public function testDefaultTtlIs24h(): void
+    private function makeCapturingCommand(): array
     {
-        $capturedData = null;
-        $command = new class($capturedData) extends CreateSecretCommand {
-            public function __construct(private mixed &$captured) {
-                parent::__construct();
-            }
+        $command = new class extends CreateSecretCommand {
+            public ?array $capturedData = null;
             protected function httpPost(string $url, array $data): string|false {
-                $this->captured = $data;
+                $this->capturedData = $data;
                 return json_encode(['id' => 'abc123']);
             }
         };
-        $tester = new CommandTester($command);
+        return [$command, new CommandTester($command)];
+    }
+
+    public function testDefaultTtlIs24h(): void
+    {
+        [$command, $tester] = $this->makeCapturingCommand();
         $status = $tester->execute(['secret' => 'my secret', 'password' => 'pass']);
 
         $this->assertSame(Command::SUCCESS, $status);
-        $this->assertSame(86400, $capturedData['ttl']);
+        $this->assertSame(86400, $command->capturedData['ttl']);
     }
 
     /**
@@ -101,21 +103,11 @@ class CreateSecretCommandTest extends TestCase
      */
     public function testValidTtlValues(string $ttlString, int $expectedSeconds): void
     {
-        $capturedData = null;
-        $command = new class($capturedData) extends CreateSecretCommand {
-            public function __construct(private mixed &$captured) {
-                parent::__construct();
-            }
-            protected function httpPost(string $url, array $data): string|false {
-                $this->captured = $data;
-                return json_encode(['id' => 'abc123']);
-            }
-        };
-        $tester = new CommandTester($command);
+        [$command, $tester] = $this->makeCapturingCommand();
         $status = $tester->execute(['secret' => 'my secret', 'password' => 'pass', '--ttl' => $ttlString]);
 
         $this->assertSame(Command::SUCCESS, $status);
-        $this->assertSame($expectedSeconds, $capturedData['ttl']);
+        $this->assertSame($expectedSeconds, $command->capturedData['ttl']);
     }
 
     public static function validTtlProvider(): array
@@ -137,5 +129,57 @@ class CreateSecretCommandTest extends TestCase
         $this->assertSame(Command::FAILURE, $status);
         $this->assertStringContainsString('Invalid TTL "2h"', $tester->getDisplay());
         $this->assertStringContainsString('1h, 6h, 24h, 3d, 7d', $tester->getDisplay());
+    }
+
+    public function testMaxViewsDefaultIsUnlimited(): void
+    {
+        [$command, $tester] = $this->makeCapturingCommand();
+        $status = $tester->execute(['secret' => 'my secret', 'password' => 'pass']);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertSame(0, $command->capturedData['max_views']);
+    }
+
+    public function testMaxViewsUnlimitedExplicit(): void
+    {
+        [$command, $tester] = $this->makeCapturingCommand();
+        $status = $tester->execute(['secret' => 'my secret', 'password' => 'pass', '--max-views' => 'unlimited']);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertSame(0, $command->capturedData['max_views']);
+    }
+
+    /**
+     * @dataProvider validMaxViewsProvider
+     */
+    public function testMaxViewsValidValues(int $maxViews): void
+    {
+        [$command, $tester] = $this->makeCapturingCommand();
+        $status = $tester->execute(['secret' => 'my secret', 'password' => 'pass', '--max-views' => (string) $maxViews]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertSame($maxViews, $command->capturedData['max_views']);
+    }
+
+    public static function validMaxViewsProvider(): array
+    {
+        return [[1], [3], [5], [10]];
+    }
+
+    /**
+     * @dataProvider invalidMaxViewsProvider
+     */
+    public function testMaxViewsInvalidValues(string $value): void
+    {
+        $tester = $this->makeCommand(json_encode(['id' => 'abc123']));
+        $status = $tester->execute(['secret' => 'my secret', 'password' => 'pass', '--max-views' => $value]);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertStringContainsString('--max-views must be one of: 1, 3, 5, 10, or unlimited', $tester->getDisplay());
+    }
+
+    public static function invalidMaxViewsProvider(): array
+    {
+        return [['0'], ['2'], ['7'], ['100'], ['none'], ['all'], ['']];
     }
 }


### PR DESCRIPTION
## Summary

Adds a `--max-views` option to the `secret:create` CLI command.

## Changes

- Added `--max-views` option to `CreateSecretCommand` accepting `1`, `3`, `5`, `10`, or `unlimited` (default)
- Validates input and returns a helpful error message for invalid values
- Passes `max_views` as an integer in the `/api/create` JSON payload (`0` for unlimited)
- Rebased onto `origin/main`, resolving conflicts with DIS-904 (`--ttl` flag) and DIS-901 (colored output); both `--ttl` and `--max-views` are now present together
- Added tests covering: default (unlimited), explicit `unlimited`, all valid integer values, and a range of invalid values

## Acceptance Criteria

- [x] `--max-views` flag works with valid values (1, 3, 5, 10, unlimited)
- [x] Invalid values show a helpful error message
- [x] Default is unlimited

Closes DIS-903
Ref: https://linear.app/displace-tech/issue/DIS-903/add-max-views-flag-to-cli-secretcreate