### PR TITLE
DIS-901: Add colored console output to CLI commands

### DIFF
--- a/cli/src/CreateSecretCommand.php
+++ b/cli/src/CreateSecretCommand.php
@@ -39,18 +39,18 @@ class CreateSecretCommand extends Command
         $response = $this->httpPost("{$serverUrl}/api/create", ['encrypted_secret' => $encryptedSecret]);
 
         if ($response === false) {
-            $output->writeln('Network error: could not reach server');
+            $output->writeln('<error>Network error: could not reach server</error>');
             return Command::FAILURE;
         }
 
         $parsed = json_decode($response, true);
         if (json_last_error() === JSON_ERROR_NONE) {
             if (isset($parsed['error'])) {
-                $output->writeln('Server error: ' . ($parsed['message'] ?? $parsed['error']));
+                $output->writeln('<error>Server error: ' . ($parsed['message'] ?? $parsed['error']) . '</error>');
                 return Command::FAILURE;
             }
             if (!isset($parsed['id'])) {
-                $output->writeln('Unexpected server response');
+                $output->writeln('<error>Unexpected server response</error>');
                 return Command::FAILURE;
             }
             $secretId = $parsed['id'];
@@ -60,8 +60,8 @@ class CreateSecretCommand extends Command
         }
 
         $output->writeln([
-            'Secret Created',
-            '==============',
+            '<info>Secret Created</info>',
+            '<info>==============</info>',
             'Secret ID: ' . $secretId,
             'Password:  ' . $password,
             '',

--- a/cli/src/RetrieveSecretCommand.php
+++ b/cli/src/RetrieveSecretCommand.php
@@ -31,7 +31,7 @@ class RetrieveSecretCommand extends Command
         $response = $this->httpPost("{$serverUrl}/api/retrieve", ['id' => $secretId, 'verifier' => $verifier]);
 
         if ($response === false) {
-            $output->writeln('Network error: could not reach server');
+            $output->writeln('<error>Network error: could not reach server</error>');
             return Command::FAILURE;
         }
 
@@ -39,23 +39,28 @@ class RetrieveSecretCommand extends Command
         if (json_last_error() === JSON_ERROR_NONE) {
             if (isset($parsed['error'])) {
                 $message = $parsed['message'] ?? $parsed['error'];
-                $output->writeln('Server error: ' . $message);
+                $friendlyMessage = match(true) {
+                    str_contains($message, 'not found') || str_contains($message, 'expired') => 'Secret not found or has expired.',
+                    str_contains($message, 'authorization') => 'Wrong password: the password you entered is incorrect.',
+                    default => 'Server error: ' . $message,
+                };
+                $output->writeln('<error>' . $friendlyMessage . '</error>');
                 return Command::FAILURE;
             }
             if (!isset($parsed['encrypted_secret'])) {
-                $output->writeln('Unexpected server response');
+                $output->writeln('<error>Unexpected server response</error>');
                 return Command::FAILURE;
             }
             $encryptedHex = $parsed['encrypted_secret'];
         } else {
             // v1 fallback: plain-text response is the hex-encoded encrypted secret
             if ($response === "Not found or expired") {
-                $output->writeln('Secret is either not found or expired!');
+                $output->writeln('<error>Secret not found or has expired.</error>');
                 return Command::FAILURE;
             }
 
             if ($response === "Invalid authorization") {
-                $output->writeln('Invalid password!');
+                $output->writeln('<error>Wrong password: the password you entered is incorrect.</error>');
                 return Command::FAILURE;
             }
 
@@ -63,7 +68,7 @@ class RetrieveSecretCommand extends Command
         }
 
         if (strlen($encryptedHex) % 2 !== 0 || !ctype_xdigit($encryptedHex)) {
-            $output->writeln('Invalid encrypted secret format received.');
+            $output->writeln('<error>Invalid encrypted secret format received.</error>');
             return Command::FAILURE;
         }
         $decoded = hex2bin($encryptedHex);
@@ -79,13 +84,13 @@ class RetrieveSecretCommand extends Command
         $decrypted = sodium_crypto_aead_aes256gcm_decrypt($ciphertext, '', $nonce, $key);
 
         if ($decrypted === false) {
-            $output->writeln('Unable to decrypt secret!');
+            $output->writeln('<error>Unable to decrypt secret. Check your password and try again.</error>');
             return Command::FAILURE;
         }
 
         $output->writeln([
-            'Secret Decrypted!',
-            '==============',
+            '<info>Secret Decrypted!</info>',
+            '<info>==============</info>',
             $decrypted
         ]);
 

--- a/cli/tests/RetrieveSecretCommandTest.php
+++ b/cli/tests/RetrieveSecretCommandTest.php
@@ -46,7 +46,7 @@ class RetrieveSecretCommandTest extends TestCase
         $status = $tester->execute(['secret-id' => 'abc123', 'password' => 'pass']);
 
         $this->assertSame(Command::FAILURE, $status);
-        $this->assertStringContainsString('Server error: Not found or expired', $tester->getDisplay());
+        $this->assertStringContainsString('Secret not found or has expired.', $tester->getDisplay());
     }
 
     public function testErrorJsonResponseWithAuthFailure(): void
@@ -55,7 +55,7 @@ class RetrieveSecretCommandTest extends TestCase
         $status = $tester->execute(['secret-id' => 'abc123', 'password' => 'pass']);
 
         $this->assertSame(Command::FAILURE, $status);
-        $this->assertStringContainsString('Server error: Invalid authorization', $tester->getDisplay());
+        $this->assertStringContainsString('Wrong password: the password you entered is incorrect.', $tester->getDisplay());
     }
 
     public function testMissingEncryptedSecretInJsonResponse(): void
@@ -83,7 +83,7 @@ class RetrieveSecretCommandTest extends TestCase
         $status = $tester->execute(['secret-id' => 'abc123', 'password' => 'pass']);
 
         $this->assertSame(Command::FAILURE, $status);
-        $this->assertStringContainsString('Secret is either not found or expired!', $tester->getDisplay());
+        $this->assertStringContainsString('Secret not found or has expired.', $tester->getDisplay());
     }
 
     public function testV1InvalidAuthResponse(): void
@@ -92,7 +92,7 @@ class RetrieveSecretCommandTest extends TestCase
         $status = $tester->execute(['secret-id' => 'abc123', 'password' => 'pass']);
 
         $this->assertSame(Command::FAILURE, $status);
-        $this->assertStringContainsString('Invalid password!', $tester->getDisplay());
+        $this->assertStringContainsString('Wrong password: the password you entered is incorrect.', $tester->getDisplay());
     }
 
     public function testMalformedJsonFallsBackToV1(): void


### PR DESCRIPTION
## DIS-901: Improve CLI error messages with color output

Linear: https://linear.app/displace-tech/issue/DIS-901/improve-cli-error-messages-with-color-output

### Changes

- **Error messages** are now wrapped in `<error>` tags (red) using Symfony Console's built-in formatter
- **Success headers** are wrapped in `<info>` tags (green)
- **Common errors** in `RetrieveSecretCommand` now produce specific, descriptive messages:
  - Server `Not found or expired` → `Secret not found or has expired.`
  - Server `Invalid authorization` → `Wrong password: the password you entered is incorrect.`
  - These specific messages apply to both the JSON API path and the v1 plain-text fallback path
- **TTY detection** is handled automatically by Symfony Console: color tags are stripped when output is piped (not a TTY), so scripts and pipes receive clean plain text

### Tests

- Updated `RetrieveSecretCommandTest` assertions to match the new specific error messages
- All 16 tests pass