### PR TITLE
DIS-902: Add --json flag for machine-readable CLI output

### DIFF
--- a/cli/src/CreateSecretCommand.php
+++ b/cli/src/CreateSecretCommand.php
@@ -5,6 +5,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateSecretCommand extends Command
@@ -28,16 +29,18 @@ class CreateSecretCommand extends Command
             ->addArgument('secret', InputArgument::REQUIRED, 'Plaintext secret to protect.')
             ->addArgument('password', InputArgument::REQUIRED, 'User-friendly password used to protect the secret.')
             ->addOption('ttl', null, InputOption::VALUE_REQUIRED, 'Time-to-live for the secret (1h, 6h, 24h, 3d, 7d).', '24h')
-            ->addOption('max-views', null, InputOption::VALUE_REQUIRED, 'Maximum number of times the secret can be viewed (1, 3, 5, 10, or unlimited).', 'unlimited');
+            ->addOption('max-views', null, InputOption::VALUE_REQUIRED, 'Maximum number of times the secret can be viewed (1, 3, 5, 10, or unlimited).', 'unlimited')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as machine-readable JSON.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $serverUrl = getenv('SWORDFISH_URL') ?: 'https://swordfish.displace.tech';
+        $jsonMode = $input->getOption('json');
 
         $ttlString = $input->getOption('ttl');
         if (!array_key_exists($ttlString, self::TTL_MAP)) {
-            $output->writeln(sprintf(
+            $this->writeError($output, $jsonMode, sprintf(
                 'Invalid TTL "%s". Allowed values: %s.',
                 $ttlString,
                 implode(', ', array_keys(self::TTL_MAP))
@@ -73,18 +76,18 @@ class CreateSecretCommand extends Command
         $response = $this->httpPost("{$serverUrl}/api/create", ['encrypted_secret' => $encryptedSecret, 'ttl' => $ttl, 'max_views' => $maxViews]);
 
         if ($response === false) {
-            $output->writeln('<error>Network error: could not reach server</error>');
+            $this->writeError($output, $jsonMode, 'Network error: could not reach server');
             return Command::FAILURE;
         }
 
         $parsed = json_decode($response, true);
         if (json_last_error() === JSON_ERROR_NONE) {
             if (isset($parsed['error'])) {
-                $output->writeln('<error>Server error: ' . ($parsed['message'] ?? $parsed['error']) . '</error>');
+                $this->writeError($output, $jsonMode, 'Server error: ' . ($parsed['message'] ?? $parsed['error']));
                 return Command::FAILURE;
             }
             if (!isset($parsed['id'])) {
-                $output->writeln('<error>Unexpected server response</error>');
+                $this->writeError($output, $jsonMode, 'Unexpected server response');
                 return Command::FAILURE;
             }
             $secretId = $parsed['id'];
@@ -93,16 +96,33 @@ class CreateSecretCommand extends Command
             $secretId = $response;
         }
 
-        $output->writeln([
-            '<info>Secret Created</info>',
-            '<info>==============</info>',
-            'Secret ID: ' . $secretId,
-            'Password:  ' . $password,
-            '',
-            'URL:       ' . $serverUrl . '/secret/' . $secretId
-        ]);
+        if ($jsonMode) {
+            $output->writeln(json_encode([
+                'id'       => $secretId,
+                'url'      => $serverUrl . '/secret/' . $secretId,
+                'password' => $password,
+            ]));
+        } else {
+            $output->writeln([
+                '<info>Secret Created</info>',
+                '<info>==============</info>',
+                'Secret ID: ' . $secretId,
+                'Password:  ' . $password,
+                '',
+                'URL:       ' . $serverUrl . '/secret/' . $secretId
+            ]);
+        }
 
         return Command::SUCCESS;
+    }
+
+    private function writeError(OutputInterface $output, bool $jsonMode, string $message): void
+    {
+        if ($jsonMode && $output instanceof ConsoleOutputInterface) {
+            $output->getErrorOutput()->writeln($message);
+        } else {
+            $output->writeln('<error>' . $message . '</error>');
+        }
     }
 
     protected function httpPost(string $url, array $data): string|false

--- a/cli/src/RetrieveSecretCommand.php
+++ b/cli/src/RetrieveSecretCommand.php
@@ -4,6 +4,8 @@ namespace Swordfish\CLI;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class RetrieveSecretCommand extends Command
@@ -15,12 +17,14 @@ class RetrieveSecretCommand extends Command
         $this->setDescription('Retrieves an encrypted secret from the server.')
             ->setHelp('This command allows you to retrieve a secret from the server and decrypt it locally.')
             ->addArgument('secret-id', InputArgument::REQUIRED, 'ID of the secret to retrieve.')
-            ->addArgument('password', InputArgument::REQUIRED, 'User-friendly password used to protect the secret.');
+            ->addArgument('password', InputArgument::REQUIRED, 'User-friendly password used to protect the secret.')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as machine-readable JSON.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $serverUrl = getenv('SWORDFISH_URL') ?: 'https://swordfish.displace.tech';
+        $jsonMode = $input->getOption('json');
 
         $password = $input->getArgument('password');
         $secretId = $input->getArgument('secret-id');
@@ -31,7 +35,7 @@ class RetrieveSecretCommand extends Command
         $response = $this->httpPost("{$serverUrl}/api/retrieve", ['id' => $secretId, 'verifier' => $verifier]);
 
         if ($response === false) {
-            $output->writeln('<error>Network error: could not reach server</error>');
+            $this->writeError($output, $jsonMode, 'Network error: could not reach server');
             return Command::FAILURE;
         }
 
@@ -39,28 +43,32 @@ class RetrieveSecretCommand extends Command
         if (json_last_error() === JSON_ERROR_NONE) {
             if (isset($parsed['error'])) {
                 $message = $parsed['message'] ?? $parsed['error'];
-                $friendlyMessage = match(true) {
-                    str_contains($message, 'not found') || str_contains($message, 'expired') => 'Secret not found or has expired.',
-                    str_contains($message, 'authorization') => 'Wrong password: the password you entered is incorrect.',
-                    default => 'Server error: ' . $message,
-                };
-                $output->writeln('<error>' . $friendlyMessage . '</error>');
+                if ($jsonMode) {
+                    $this->writeError($output, true, 'Server error: ' . $message);
+                } else {
+                    $friendlyMessage = match(true) {
+                        str_contains($message, 'not found') || str_contains($message, 'expired') => 'Secret not found or has expired.',
+                        str_contains($message, 'authorization') => 'Wrong password: the password you entered is incorrect.',
+                        default => 'Server error: ' . $message,
+                    };
+                    $this->writeError($output, false, $friendlyMessage);
+                }
                 return Command::FAILURE;
             }
             if (!isset($parsed['encrypted_secret'])) {
-                $output->writeln('<error>Unexpected server response</error>');
+                $this->writeError($output, $jsonMode, 'Unexpected server response');
                 return Command::FAILURE;
             }
             $encryptedHex = $parsed['encrypted_secret'];
         } else {
             // v1 fallback: plain-text response is the hex-encoded encrypted secret
             if ($response === "Not found or expired") {
-                $output->writeln('<error>Secret not found or has expired.</error>');
+                $this->writeError($output, $jsonMode, 'Secret not found or has expired.');
                 return Command::FAILURE;
             }
 
             if ($response === "Invalid authorization") {
-                $output->writeln('<error>Wrong password: the password you entered is incorrect.</error>');
+                $this->writeError($output, $jsonMode, 'Wrong password: the password you entered is incorrect.');
                 return Command::FAILURE;
             }
 
@@ -68,7 +76,7 @@ class RetrieveSecretCommand extends Command
         }
 
         if (strlen($encryptedHex) % 2 !== 0 || !ctype_xdigit($encryptedHex)) {
-            $output->writeln('<error>Invalid encrypted secret format received.</error>');
+            $this->writeError($output, $jsonMode, 'Invalid encrypted secret format received.');
             return Command::FAILURE;
         }
         $decoded = hex2bin($encryptedHex);
@@ -84,17 +92,30 @@ class RetrieveSecretCommand extends Command
         $decrypted = sodium_crypto_aead_aes256gcm_decrypt($ciphertext, '', $nonce, $key);
 
         if ($decrypted === false) {
-            $output->writeln('<error>Unable to decrypt secret. Check your password and try again.</error>');
+            $this->writeError($output, $jsonMode, 'Unable to decrypt secret. Check your password and try again.');
             return Command::FAILURE;
         }
 
-        $output->writeln([
-            '<info>Secret Decrypted!</info>',
-            '<info>==============</info>',
-            $decrypted
-        ]);
+        if ($jsonMode) {
+            $output->writeln(json_encode(['secret' => $decrypted]));
+        } else {
+            $output->writeln([
+                '<info>Secret Decrypted!</info>',
+                '<info>==============</info>',
+                $decrypted
+            ]);
+        }
 
         return Command::SUCCESS;
+    }
+
+    private function writeError(OutputInterface $output, bool $jsonMode, string $message): void
+    {
+        if ($jsonMode && $output instanceof ConsoleOutputInterface) {
+            $output->getErrorOutput()->writeln($message);
+        } else {
+            $output->writeln('<error>' . $message . '</error>');
+        }
     }
 
     protected function httpPost(string $url, array $data): string|false

--- a/cli/tests/CreateSecretCommandTest.php
+++ b/cli/tests/CreateSecretCommandTest.php
@@ -182,4 +182,43 @@ class CreateSecretCommandTest extends TestCase
     {
         return [['0'], ['2'], ['7'], ['100'], ['none'], ['all'], ['']];
     }
+
+    public function testJsonFlagOutputsValidJson(): void
+    {
+        $tester = $this->makeCommand(json_encode(['id' => 'abc123']));
+        $status = $tester->execute(['secret' => 'my secret', 'password' => 'pass', '--json' => true]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $decoded = json_decode(trim($tester->getDisplay()), true);
+        $this->assertSame(JSON_ERROR_NONE, json_last_error());
+        $this->assertSame('abc123', $decoded['id']);
+        $this->assertSame('pass', $decoded['password']);
+        $this->assertStringContainsString('/secret/abc123', $decoded['url']);
+    }
+
+    public function testJsonFlagErrorGoesToStderr(): void
+    {
+        $tester = $this->makeCommand(json_encode(['error' => true, 'message' => 'Storage full']));
+        $status = $tester->execute(
+            ['secret' => 'my secret', 'password' => 'pass', '--json' => true],
+            ['capture_stderr_separately' => true]
+        );
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertEmpty(trim($tester->getDisplay()));
+        $this->assertStringContainsString('Server error: Storage full', $tester->getErrorOutput());
+    }
+
+    public function testJsonFlagNetworkErrorGoesToStderr(): void
+    {
+        $tester = $this->makeCommand(false);
+        $status = $tester->execute(
+            ['secret' => 'my secret', 'password' => 'pass', '--json' => true],
+            ['capture_stderr_separately' => true]
+        );
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertEmpty(trim($tester->getDisplay()));
+        $this->assertStringContainsString('Network error', $tester->getErrorOutput());
+    }
 }

--- a/cli/tests/RetrieveSecretCommandTest.php
+++ b/cli/tests/RetrieveSecretCommandTest.php
@@ -123,4 +123,42 @@ class RetrieveSecretCommandTest extends TestCase
         $this->assertSame(Command::FAILURE, $status);
         $this->assertStringContainsString('Network error', $tester->getDisplay());
     }
+
+    public function testJsonFlagOutputsValidJson(): void
+    {
+        $encryptedHex = $this->buildEncryptedHex('my secret', 'pass');
+        $tester = $this->makeCommand(json_encode(['encrypted_secret' => $encryptedHex]));
+        $status = $tester->execute(['secret-id' => 'abc123', 'password' => 'pass', '--json' => true]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $decoded = json_decode(trim($tester->getDisplay()), true);
+        $this->assertSame(JSON_ERROR_NONE, json_last_error());
+        $this->assertSame('my secret', $decoded['secret']);
+    }
+
+    public function testJsonFlagErrorGoesToStderr(): void
+    {
+        $tester = $this->makeCommand(json_encode(['error' => true, 'message' => 'Not found or expired']));
+        $status = $tester->execute(
+            ['secret-id' => 'abc123', 'password' => 'pass', '--json' => true],
+            ['capture_stderr_separately' => true]
+        );
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertEmpty(trim($tester->getDisplay()));
+        $this->assertStringContainsString('Server error: Not found or expired', $tester->getErrorOutput());
+    }
+
+    public function testJsonFlagNetworkErrorGoesToStderr(): void
+    {
+        $tester = $this->makeCommand(false);
+        $status = $tester->execute(
+            ['secret-id' => 'abc123', 'password' => 'pass', '--json' => true],
+            ['capture_stderr_separately' => true]
+        );
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertEmpty(trim($tester->getDisplay()));
+        $this->assertStringContainsString('Network error', $tester->getErrorOutput());
+    }
 }

--- a/frontend/src/__tests__/setup.js
+++ b/frontend/src/__tests__/setup.js
@@ -1,1 +1,18 @@
 import '@testing-library/jest-dom'
+
+// jsdom does not implement window.matchMedia; provide a minimal stub.
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+}


### PR DESCRIPTION
## Summary

Adds a `--json` flag to `secret:create` and `secret:retrieve` for machine-readable output.

Closes / references: DIS-902 https://linear.app/displace-tech/issue/DIS-902/add-json-flag-for-machine-readable-cli-output

## Changes

- `secret:create --json` outputs `{"id", "url", "password"}` as JSON to stdout
- `secret:retrieve --json` outputs `{"secret"}` as JSON to stdout
- When `--json` is set, all error messages are written to stderr instead of stdout
- Output is parseable by `jq`
- Rebased onto `main` to incorporate `--ttl` flag (DIS-904) and colored output (DIS-901)

## Tests

Added 6 new tests (3 per command):

- `testJsonFlagOutputsValidJson` — verifies stdout is valid, parseable JSON on success
- `testJsonFlagErrorGoesToStderr` — verifies server errors go to stderr, not stdout
- `testJsonFlagNetworkErrorGoesToStderr` — verifies network errors go to stderr, not stdout

All 29 tests pass.