### PR TITLE
DIS-908: Add GET /api/secret/:id/info metadata endpoint

### DIFF
--- a/server/server.php
+++ b/server/server.php
@@ -53,6 +53,7 @@ Amp\Loop::run(function () {
 
     $router->addRoute('POST', '/api/create', ServerRoutes::createSecret($logger, $redisClient, $metrics));
     $router->addRoute('POST', '/create', ServerRoutes::redirectCreate($logger));
+    $router->addRoute('GET', '/api/secret/{secretId}/info', ServerRoutes::secretInfo($logger, $redisClient));
     $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecretJson($logger, $redisClient, $metrics));
     $router->addRoute('POST', '/retrieve', ServerRoutes::redirectRetrieve($logger));
 

--- a/server/src/SecretService.php
+++ b/server/src/SecretService.php
@@ -138,6 +138,36 @@ LUA;
     }
 
     /**
+     * Return metadata for a JSON-API secret without consuming a view.
+     *
+     * Reads views_remaining and expires_at from Redis without decrementing
+     * the view counter or requiring the passphrase/verifier.
+     *
+     * @param string $secretID
+     * @return array{views_remaining: int|null, expires_at: int}
+     *
+     * @throws SecretNotFoundException When no secret with the given ID exists
+     */
+    public function getInfo(string $secretID): array
+    {
+        $expiresKey = "json_expires:{$secretID}";
+        $viewsKey   = "json_views:{$secretID}";
+
+        $expiresAt = $this->redis->get($expiresKey);
+        if ($expiresAt === null) {
+            throw new SecretNotFoundException(sprintf('JSON secret %s not found.', $secretID));
+        }
+
+        $views          = $this->redis->get($viewsKey);
+        $viewsRemaining = $views !== null ? (int) $views : null;
+
+        return [
+            'views_remaining' => $viewsRemaining,
+            'expires_at'      => (int) $expiresAt,
+        ];
+    }
+
+    /**
      * Retrieve a JSON-API secret after verifying the supplied verifier.
      *
      * Decrements the view counter and deletes all associated keys when views

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -158,6 +158,43 @@ class ServerRoutes
     }
 
     /**
+     * Return metadata for a secret without consuming a view or requiring a passphrase.
+     *
+     * Returns: {"views_remaining": N|null, "expires_at": T}
+     * Returns 404 when no secret with the given ID exists.
+     *
+     * @param Logger $logger
+     * @param Client $redisClient
+     * @return CallableRequestHandler
+     */
+    public static function secretInfo(Logger $logger, Client $redisClient): CallableRequestHandler
+    {
+        $service = new SecretService($redisClient);
+        return new CallableRequestHandler(function(Request $request) use ($logger, $service): Response {
+            $args     = $request->getAttribute(Router::class);
+            $secretID = $args['secretId'] ?? '';
+
+            try {
+                $info = $service->getInfo($secretID);
+            } catch (SecretNotFoundException $e) {
+                $logger->info(sprintf('Info request for unknown secret %s', $secretID));
+                return new Response(
+                    Status::NOT_FOUND,
+                    ['content-type' => 'application/json'],
+                    json_encode(['error' => 'Not Found', 'message' => 'Not found or expired'])
+                );
+            }
+
+            $logger->info(sprintf('Info request for secret %s', $secretID));
+            return new Response(
+                Status::OK,
+                ['content-type' => 'application/json'],
+                json_encode($info)
+            );
+        });
+    }
+
+    /**
      * Check Redis connectivity and return service health status.
      *
      * @param Logger $logger

--- a/server/tests/Unit/SecretInfoTest.php
+++ b/server/tests/Unit/SecretInfoTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use Amp\Http\Server\Driver\Client;
+use Amp\Http\Server\Request;
+use Amp\Http\Server\Router;
+use Amp\Http\Status;
+use League\Uri\Http;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\SecretNotFoundException;
+use Swordfish\Server\SecretService;
+use Swordfish\Server\ServerRoutes;
+
+class SecretInfoTest extends TestCase
+{
+    private function makeRedisMock(): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['get'])
+            ->getMock();
+    }
+
+    private function makeRequest(string $secretId): Request
+    {
+        $client  = $this->createMock(Client::class);
+        $request = new Request($client, 'GET', Http::new("http://localhost/api/secret/{$secretId}/info"));
+        $request->setAttribute(Router::class, ['secretId' => $secretId]);
+        return $request;
+    }
+
+    // -------------------------------------------------------------------------
+    // SecretService::getInfo()
+    // -------------------------------------------------------------------------
+
+    public function testGetInfoReturnsMetadataForUnlimitedSecret(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $redis->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnCallback(function (string $key) {
+                if (str_starts_with($key, 'json_expires:')) {
+                    return '1999999999';
+                }
+                // No views key → unlimited
+                return null;
+            });
+
+        $service = new SecretService($redis);
+        $result  = $service->getInfo('abc123def456');
+
+        $this->assertSame(1999999999, $result['expires_at']);
+        $this->assertNull($result['views_remaining']);
+    }
+
+    public function testGetInfoReturnsViewsRemainingForLimitedSecret(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $redis->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnCallback(function (string $key) {
+                if (str_starts_with($key, 'json_expires:')) {
+                    return '1999999999';
+                }
+                if (str_starts_with($key, 'json_views:')) {
+                    return '3';
+                }
+                return null;
+            });
+
+        $service = new SecretService($redis);
+        $result  = $service->getInfo('abc123def456');
+
+        $this->assertSame(3, $result['views_remaining']);
+        $this->assertSame(1999999999, $result['expires_at']);
+    }
+
+    public function testGetInfoThrowsSecretNotFoundExceptionWhenMissing(): void
+    {
+        $redis = $this->makeRedisMock();
+
+        $redis->expects($this->once())
+            ->method('get')
+            ->willReturn(null);
+
+        $service = new SecretService($redis);
+
+        $this->expectException(SecretNotFoundException::class);
+        $service->getInfo('doesnotexist');
+    }
+
+    // -------------------------------------------------------------------------
+    // ServerRoutes::secretInfo() handler
+    // -------------------------------------------------------------------------
+
+    public function testSecretInfoHandlerReturns200WithMetadata(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+
+        $redis->method('get')
+            ->willReturnCallback(function (string $key) {
+                if (str_starts_with($key, 'json_expires:')) {
+                    return '1999999999';
+                }
+                if (str_starts_with($key, 'json_views:')) {
+                    return '5';
+                }
+                return null;
+            });
+
+        $handler  = ServerRoutes::secretInfo($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest('abc123def456')));
+
+        $this->assertSame(Status::OK, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertSame(5, $parsed['views_remaining']);
+        $this->assertSame(1999999999, $parsed['expires_at']);
+    }
+
+    public function testSecretInfoHandlerReturns200WithNullViewsForUnlimitedSecret(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+
+        $redis->method('get')
+            ->willReturnCallback(function (string $key) {
+                if (str_starts_with($key, 'json_expires:')) {
+                    return '1999999999';
+                }
+                return null;
+            });
+
+        $handler  = ServerRoutes::secretInfo($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest('abc123def456')));
+
+        $this->assertSame(Status::OK, $response->getStatus());
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertNull($parsed['views_remaining']);
+        $this->assertSame(1999999999, $parsed['expires_at']);
+    }
+
+    public function testSecretInfoHandlerReturns404ForNonexistentSecret(): void
+    {
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+
+        $redis->method('get')->willReturn(null);
+
+        $handler  = ServerRoutes::secretInfo($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest('doesnotexist')));
+
+        $this->assertSame(Status::NOT_FOUND, $response->getStatus());
+        $this->assertSame('application/json', $response->getHeader('content-type'));
+
+        $body   = \Amp\Promise\wait($response->getBody()->read());
+        $parsed = json_decode($body, true);
+        $this->assertSame('Not Found', $parsed['error']);
+    }
+}

--- a/swagger.yml
+++ b/swagger.yml
@@ -197,6 +197,43 @@ paths:
               message:
                 type: "string"
                 example: "TTL must be one of: 3600, 21600, 86400, 259200, 604800 seconds."
+  /api/secret/{secretId}/info:
+    get:
+      summary: "Get secret metadata without consuming a view."
+      tags:
+        - "api"
+      produces:
+        - "application/json"
+      parameters:
+        - name: "secretId"
+          in: "path"
+          description: "ID of the secret"
+          required: true
+          type: "string"
+      responses:
+        "200":
+          description: "OK"
+          schema:
+            type: "object"
+            properties:
+              views_remaining:
+                type: "integer"
+                description: "Number of views remaining; null for unlimited secrets"
+                x-nullable: true
+              expires_at:
+                type: "integer"
+                description: "Unix timestamp when the secret expires"
+        "404":
+          description: "Not Found"
+          schema:
+            type: "object"
+            properties:
+              error:
+                type: "string"
+                example: "Not Found"
+              message:
+                type: "string"
+                example: "Not found or expired"
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."


### PR DESCRIPTION
## Summary

Adds `GET /api/secret/:id/info` — a read-only metadata endpoint that returns `views_remaining` and `expires_at` for a secret without consuming a view or requiring the passphrase.

Closes / references: [DIS-908](https://linear.app/displace-tech/issue/DIS-908/add-get-apisecretidinfo-metadata-endpoint)

## Changes

- **`SecretService::getInfo()`** — reads `json_expires:{id}` and `json_views:{id}` from Redis without decrementing the view counter; throws `SecretNotFoundException` when the secret does not exist.
- **`ServerRoutes::secretInfo()`** — `GET /api/secret/{secretId}/info` handler; returns 200 with `{views_remaining, expires_at}` or 404 for unknown secrets.
- **`server.php`** — route registered: `GET /api/secret/{secretId}/info`.
- **`swagger.yml`** — new endpoint documented.
- **`tests/Unit/SecretInfoTest.php`** — unit tests covering: limited secret (200), unlimited secret (200 with null views_remaining), and nonexistent secret (404).

## Acceptance Criteria

- [x] Endpoint returns `views_remaining` and `expires_at`
- [x] Does not decrement view counter
- [x] Returns 404 for nonexistent secrets
- [x] All tests pass