### PR TITLE
DIS-905: Add GET /api/metrics Prometheus endpoint

### DIFF
--- a/server/server.php
+++ b/server/server.php
@@ -56,6 +56,7 @@ Amp\Loop::run(function () {
     $router->addRoute('GET', '/api/secret/{secretId}/info', ServerRoutes::secretInfo($logger, $redisClient));
     $router->addRoute('POST', '/api/retrieve', ServerRoutes::retrieveSecretJson($logger, $redisClient, $metrics));
     $router->addRoute('POST', '/retrieve', ServerRoutes::redirectRetrieve($logger));
+    $router->addRoute('GET', '/api/metrics', ServerRoutes::metricsEndpoint($logger, $redisClient));
 
     $router->setFallback(ServerRoutes::spaFallback($logger, $documentRoot));
 

--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -243,6 +243,56 @@ class ServerRoutes
     }
 
     /**
+     * Serve Prometheus-format metrics by summing hourly Redis counters.
+     *
+     * If the METRICS_TOKEN environment variable is set, the request must include
+     * a matching "Authorization: Bearer <token>" header; otherwise 401 is returned.
+     *
+     * @param Logger $logger
+     * @param Client $redisClient
+     * @return CallableRequestHandler
+     */
+    public static function metricsEndpoint(Logger $logger, Client $redisClient): CallableRequestHandler
+    {
+        return new CallableRequestHandler(function(Request $request) use ($logger, $redisClient): Response {
+            $token = getenv('METRICS_TOKEN');
+            if ($token !== false && $token !== '') {
+                $authHeader = $request->getHeader('authorization') ?? '';
+                if ($authHeader !== 'Bearer ' . $token) {
+                    $logger->warning('Metrics request rejected: invalid or missing token');
+                    return new Response(Status::UNAUTHORIZED, ['content-type' => 'text/plain'], 'Unauthorized');
+                }
+            }
+
+            $metricDefs = [
+                'secrets_created_total'   => ['pattern' => 'metrics:created:*',       'help' => 'Total number of secrets created'],
+                'secrets_retrieved_total' => ['pattern' => 'metrics:retrieved:*',     'help' => 'Total number of secrets retrieved'],
+                'bytes_stored_total'      => ['pattern' => 'metrics:bytes_stored:*',  'help' => 'Total bytes stored in secrets'],
+                'bytes_retrieved_total'   => ['pattern' => 'metrics:bytes_retrieved:*', 'help' => 'Total bytes retrieved from secrets'],
+            ];
+
+            $lines = [];
+            foreach ($metricDefs as $name => $def) {
+                $keys  = $redisClient->keys($def['pattern']);
+                $total = 0;
+                if (!empty($keys)) {
+                    $values = $redisClient->mget($keys);
+                    foreach ($values as $v) {
+                        $total += (int) $v;
+                    }
+                }
+                $lines[] = sprintf('# HELP %s %s', $name, $def['help']);
+                $lines[] = sprintf('# TYPE %s counter', $name);
+                $lines[] = sprintf('%s %d', $name, $total);
+            }
+
+            $body = implode("\n", $lines) . "\n";
+            $logger->info('Metrics endpoint served');
+            return new Response(Status::OK, ['content-type' => 'text/plain; version=0.0.4'], $body);
+        });
+    }
+
+    /**
      * Handle API requests to retrieve a secret.
      *
      * @param Logger $logger

--- a/server/tests/Unit/MetricsEndpointTest.php
+++ b/server/tests/Unit/MetricsEndpointTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use Amp\Http\Server\Driver\Client;
+use Amp\Http\Server\Request;
+use Amp\Http\Status;
+use League\Uri\Http;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\ServerRoutes;
+
+class MetricsEndpointTest extends TestCase
+{
+    private function makeRequest(array $headers = []): Request
+    {
+        $client  = $this->createMock(Client::class);
+        $request = new Request($client, 'GET', Http::new('http://localhost/api/metrics'), $headers);
+        return $request;
+    }
+
+    private function makeRedisMock(): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['keys', 'mget'])
+            ->getMock();
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth checks
+    // -------------------------------------------------------------------------
+
+    public function testReturns401WhenTokenConfiguredAndMissing(): void
+    {
+        putenv('METRICS_TOKEN=secret-token');
+
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->never())->method('keys');
+
+        $handler  = ServerRoutes::metricsEndpoint($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+
+        $this->assertSame(Status::UNAUTHORIZED, $response->getStatus());
+
+        putenv('METRICS_TOKEN');
+    }
+
+    public function testReturns401WhenTokenConfiguredAndWrong(): void
+    {
+        putenv('METRICS_TOKEN=secret-token');
+
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->expects($this->never())->method('keys');
+
+        $handler  = ServerRoutes::metricsEndpoint($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest(
+            $this->makeRequest(['authorization' => 'Bearer wrong-token'])
+        ));
+
+        $this->assertSame(Status::UNAUTHORIZED, $response->getStatus());
+
+        putenv('METRICS_TOKEN');
+    }
+
+    public function testReturns200WhenTokenConfiguredAndCorrect(): void
+    {
+        putenv('METRICS_TOKEN=secret-token');
+
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->method('keys')->willReturn([]);
+
+        $handler  = ServerRoutes::metricsEndpoint($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest(
+            $this->makeRequest(['authorization' => 'Bearer secret-token'])
+        ));
+
+        $this->assertSame(Status::OK, $response->getStatus());
+
+        putenv('METRICS_TOKEN');
+    }
+
+    public function testReturns200WhenNoTokenConfigured(): void
+    {
+        putenv('METRICS_TOKEN');
+
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->method('keys')->willReturn([]);
+
+        $handler  = ServerRoutes::metricsEndpoint($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+
+        $this->assertSame(Status::OK, $response->getStatus());
+    }
+
+    // -------------------------------------------------------------------------
+    // Response format
+    // -------------------------------------------------------------------------
+
+    public function testResponseHasPrometheusContentType(): void
+    {
+        putenv('METRICS_TOKEN');
+
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->method('keys')->willReturn([]);
+
+        $handler  = ServerRoutes::metricsEndpoint($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+
+        $this->assertSame('text/plain; version=0.0.4', $response->getHeader('content-type'));
+    }
+
+    public function testResponseContainsAllFourMetrics(): void
+    {
+        putenv('METRICS_TOKEN');
+
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->method('keys')->willReturn([]);
+
+        $handler  = ServerRoutes::metricsEndpoint($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+        $body     = \Amp\Promise\wait($response->getBody()->read());
+
+        $this->assertStringContainsString('secrets_created_total', $body);
+        $this->assertStringContainsString('secrets_retrieved_total', $body);
+        $this->assertStringContainsString('bytes_stored_total', $body);
+        $this->assertStringContainsString('bytes_retrieved_total', $body);
+    }
+
+    public function testResponseIncludesHelpAndTypeLines(): void
+    {
+        putenv('METRICS_TOKEN');
+
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->method('keys')->willReturn([]);
+
+        $handler  = ServerRoutes::metricsEndpoint($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+        $body     = \Amp\Promise\wait($response->getBody()->read());
+
+        $this->assertStringContainsString('# HELP secrets_created_total', $body);
+        $this->assertStringContainsString('# TYPE secrets_created_total counter', $body);
+        $this->assertStringContainsString('# HELP secrets_retrieved_total', $body);
+        $this->assertStringContainsString('# TYPE secrets_retrieved_total counter', $body);
+        $this->assertStringContainsString('# HELP bytes_stored_total', $body);
+        $this->assertStringContainsString('# TYPE bytes_stored_total counter', $body);
+        $this->assertStringContainsString('# HELP bytes_retrieved_total', $body);
+        $this->assertStringContainsString('# TYPE bytes_retrieved_total counter', $body);
+    }
+
+    public function testReturnsZeroCountersWhenNoKeysExist(): void
+    {
+        putenv('METRICS_TOKEN');
+
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+        $redis->method('keys')->willReturn([]);
+
+        $handler  = ServerRoutes::metricsEndpoint($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+        $body     = \Amp\Promise\wait($response->getBody()->read());
+
+        $this->assertStringContainsString('secrets_created_total 0', $body);
+        $this->assertStringContainsString('secrets_retrieved_total 0', $body);
+        $this->assertStringContainsString('bytes_stored_total 0', $body);
+        $this->assertStringContainsString('bytes_retrieved_total 0', $body);
+    }
+
+    public function testSumsMultipleHourlyKeysForEachMetric(): void
+    {
+        putenv('METRICS_TOKEN');
+
+        $logger = new Logger('test');
+        $redis  = $this->makeRedisMock();
+
+        $redis->method('keys')
+            ->willReturnCallback(function (string $pattern): array {
+                return match (true) {
+                    str_contains($pattern, 'metrics:created:')        => ['metrics:created:2024-01-01:10', 'metrics:created:2024-01-01:11'],
+                    str_contains($pattern, 'metrics:retrieved:')      => ['metrics:retrieved:2024-01-01:10'],
+                    str_contains($pattern, 'metrics:bytes_stored:')   => ['metrics:bytes_stored:2024-01-01:10', 'metrics:bytes_stored:2024-01-01:11'],
+                    str_contains($pattern, 'metrics:bytes_retrieved:') => ['metrics:bytes_retrieved:2024-01-01:10'],
+                    default => [],
+                };
+            });
+
+        $redis->method('mget')
+            ->willReturnCallback(function (array $keys): array {
+                return match (count($keys)) {
+                    2 => ['10', '5'],
+                    1 => ['7'],
+                    default => [],
+                };
+            });
+
+        $handler  = ServerRoutes::metricsEndpoint($logger, $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeRequest()));
+        $body     = \Amp\Promise\wait($response->getBody()->read());
+
+        $this->assertStringContainsString('secrets_created_total 15', $body);
+        $this->assertStringContainsString('secrets_retrieved_total 7', $body);
+    }
+}

--- a/swagger.yml
+++ b/swagger.yml
@@ -234,6 +234,24 @@ paths:
               message:
                 type: "string"
                 example: "Not found or expired"
+  /api/metrics:
+    get:
+      summary: "Retrieve Prometheus-format metrics counters."
+      tags:
+        - "api"
+      produces:
+        - "text/plain"
+      parameters:
+        - name: "Authorization"
+          in: "header"
+          description: "Bearer token (required only when METRICS_TOKEN env var is set)"
+          required: false
+          type: "string"
+      responses:
+        "200":
+          description: "Prometheus text format metrics"
+        "401":
+          description: "Unauthorized — token required but missing or invalid"
   /api/retrieve:
     post:
       summary: "Retrieve a secret from the datastore."


### PR DESCRIPTION
## DIS-905: Implement GET /api/metrics Prometheus endpoint

Linear: https://linear.app/displace-tech/issue/DIS-905/implement-get-apimetrics-prometheus-endpoint

### What

Adds a `GET /api/metrics` endpoint that reads the hourly Redis counters written by `MetricsService` and returns them in Prometheus text format.

### Changes

- **`server/src/ServerRoutes.php`** — New `metricsEndpoint()` handler:
  - Sums all hourly `metrics:created:*`, `metrics:retrieved:*`, `metrics:bytes_stored:*`, and `metrics:bytes_retrieved:*` Redis keys into four Prometheus counters: `secrets_created_total`, `secrets_retrieved_total`, `bytes_stored_total`, `bytes_retrieved_total`
  - Returns `text/plain; version=0.0.4` (standard Prometheus content-type) with `# HELP`, `# TYPE`, and value lines for each metric
  - Optional bearer-token auth: if `METRICS_TOKEN` env var is set, the request must include a matching `Authorization: Bearer <token>` header; requests without a valid token receive `401 Unauthorized`
- **`server/server.php`** — Registers `GET /api/metrics` route
- **`server/tests/Unit/MetricsEndpointTest.php`** — 9 unit tests covering auth enforcement, response format, content-type, zero-value counters, and multi-key aggregation
- **`swagger.yml`** — Documents the new endpoint

### Acceptance Criteria

- [x] `GET /api/metrics` returns valid Prometheus text format
- [x] Gauges/counters for `secrets_created_total`, `secrets_retrieved_total`, `bytes_stored_total`, `bytes_retrieved_total`
- [x] Auth token check works if `METRICS_TOKEN` is configured
- [x] All tests pass