### PR TITLE
DIS-912: Add security response headers to PHP server

### DIFF
--- a/server/src/ServerRoutes.php
+++ b/server/src/ServerRoutes.php
@@ -14,6 +14,22 @@ use Predis\Client;
 class ServerRoutes
 {
     /**
+     * Return the standard security response headers for all responses.
+     *
+     * @return array<string, string>
+     */
+    private static function securityHeaders(): array
+    {
+        return [
+            'Content-Security-Policy'   => "default-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'none'",
+            'X-Content-Type-Options'    => 'nosniff',
+            'X-Frame-Options'           => 'DENY',
+            'Referrer-Policy'           => 'strict-origin-when-cross-origin',
+            'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains',
+        ];
+    }
+
+    /**
      * Create a callback that serves the SPA index.html for the main landing page.
      *
      * @param Logger $logger
@@ -24,7 +40,7 @@ class ServerRoutes
         return new CallableRequestHandler(function() use ($logger): Response {
             $logger->info('Main page load');
             $html = file_get_contents(__DIR__ . '/../static/index.html');
-            return new Response(Status::OK, ['content-type' => 'text/html'], $html);
+            return new Response(Status::OK, array_merge(['content-type' => 'text/html'], self::securityHeaders()), $html);
         });
     }
 
@@ -46,7 +62,7 @@ class ServerRoutes
             }
 
             $html = file_get_contents(__DIR__ . '/../static/index.html');
-            return new Response(Status::OK, ['content-type' => 'text/html'], $html);
+            return new Response(Status::OK, array_merge(['content-type' => 'text/html'], self::securityHeaders()), $html);
         });
     }
 
@@ -65,7 +81,10 @@ class ServerRoutes
             $response = yield $documentRoot->handleRequest($request);
             if ($request->getMethod() === 'GET' && $response->getStatus() === Status::NOT_FOUND) {
                 $logger->info(sprintf('SPA fallback for %s', $request->getUri()->getPath()));
-                return new Response(Status::OK, ['content-type' => 'text/html'], $indexHtml);
+                return new Response(Status::OK, array_merge(['content-type' => 'text/html'], self::securityHeaders()), $indexHtml);
+            }
+            foreach (self::securityHeaders() as $name => $value) {
+                $response->setHeader($name, $value);
             }
             return $response;
         });
@@ -81,7 +100,7 @@ class ServerRoutes
     {
         return new CallableRequestHandler(function() use ($logger): Response {
             $logger->info('Redirecting POST /create to POST /api/create');
-            return new Response(Status::PERMANENT_REDIRECT, ['location' => '/api/create'], '');
+            return new Response(Status::PERMANENT_REDIRECT, array_merge(['location' => '/api/create'], self::securityHeaders()), '');
         });
     }
 
@@ -95,7 +114,7 @@ class ServerRoutes
     {
         return new CallableRequestHandler(function() use ($logger): Response {
             $logger->info('Redirecting POST /retrieve to POST /api/retrieve');
-            return new Response(Status::PERMANENT_REDIRECT, ['location' => '/api/retrieve'], '');
+            return new Response(Status::PERMANENT_REDIRECT, array_merge(['location' => '/api/retrieve'], self::securityHeaders()), '');
         });
     }
 
@@ -119,7 +138,7 @@ class ServerRoutes
                 $logger->error('Message payload too large!');
                 return new Response(
                     Status::PAYLOAD_TOO_LARGE,
-                    ['content-type' => 'application/json'],
+                    array_merge(['content-type' => 'application/json'], self::securityHeaders()),
                     json_encode(['error' => 'Payload Too Large', 'message' => 'Request body exceeds maximum allowed size'])
                 );
             }
@@ -130,14 +149,14 @@ class ServerRoutes
                 $logger->error('Invalid parameter in creation request: ' . $e->getMessage());
                 return new Response(
                     Status::UNPROCESSABLE_ENTITY,
-                    ['content-type' => 'application/json'],
+                    array_merge(['content-type' => 'application/json'], self::securityHeaders()),
                     json_encode(['error' => 'Unprocessable Entity', 'message' => $e->getMessage()])
                 );
             } catch (\Exception $e) {
                 $logger->error('Unable to decode creation request: ' . $e->getMessage());
                 return new Response(
                     Status::BAD_REQUEST,
-                    ['content-type' => 'application/json'],
+                    array_merge(['content-type' => 'application/json'], self::securityHeaders()),
                     json_encode(['error' => 'Bad Request', 'message' => 'Invalid or missing JSON fields'])
                 );
             }
@@ -151,7 +170,7 @@ class ServerRoutes
 
             return new Response(
                 Status::CREATED,
-                ['content-type' => 'application/json'],
+                array_merge(['content-type' => 'application/json'], self::securityHeaders()),
                 json_encode(['id' => $secretID, 'expires_at' => $expiresAt, 'max_views' => $maxViews])
             );
         });
@@ -172,14 +191,14 @@ class ServerRoutes
                 $logger->info('Health check: Redis reachable');
                 return new Response(
                     Status::OK,
-                    ['content-type' => 'application/json'],
+                    array_merge(['content-type' => 'application/json'], self::securityHeaders()),
                     json_encode(['status' => 'ok'])
                 );
             } catch (\Exception $e) {
                 $logger->error('Health check: Redis unreachable - ' . $e->getMessage());
                 return new Response(
                     Status::SERVICE_UNAVAILABLE,
-                    ['content-type' => 'application/json'],
+                    array_merge(['content-type' => 'application/json'], self::securityHeaders()),
                     json_encode(['status' => 'error', 'message' => $e->getMessage()])
                 );
             }
@@ -203,7 +222,7 @@ class ServerRoutes
                 $retrievalRequest = RetrievalRequest::fromString($data);
             } catch (\Exception $e) {
                 $logger->error('Unable to decode retrieval request');
-                return new Response(Status::BAD_REQUEST, ['content-type' => 'text/plain'], 'Bad Request');
+                return new Response(Status::BAD_REQUEST, array_merge(['content-type' => 'text/plain'], self::securityHeaders()), 'Bad Request');
             }
 
             $secretID = $retrievalRequest->ID();
@@ -213,13 +232,13 @@ class ServerRoutes
                 $secret = $service->retrieve($secretID, $verifier);
             } catch (InvalidVerifierException $e) {
                 $logger->error(sprintf('Secret %s requested with an invalid password.', $secretID));
-                return new Response(Status::UNAUTHORIZED, ['content-type' => 'text/plain'], 'Invalid authorization');
+                return new Response(Status::UNAUTHORIZED, array_merge(['content-type' => 'text/plain'], self::securityHeaders()), 'Invalid authorization');
             } catch (SecretNotFoundException $e) {
                 $logger->error(sprintf('Secret %s was requested but was not found.', $secretID));
-                return new Response(Status::NOT_FOUND, ['content-type' => 'text/plain'], 'Not found or expired');
+                return new Response(Status::NOT_FOUND, array_merge(['content-type' => 'text/plain'], self::securityHeaders()), 'Not found or expired');
             }
 
-            return new Response(Status::OK, ['content-type' => 'text/plain'], $secret);
+            return new Response(Status::OK, array_merge(['content-type' => 'text/plain'], self::securityHeaders()), $secret);
         });
     }
 
@@ -245,11 +264,14 @@ class ServerRoutes
         return new CallableRequestHandler(function (Request $request) use ($logger, $service, $rateLimiter, $metrics) {
             $ip          = $request->getClient()->getRemoteAddress()->getHost();
             $rateLimit   = $rateLimiter->isAllowed($ip);
-            $rlHeaders   = [
-                'X-RateLimit-Limit'     => (string) $rateLimit['limit'],
-                'X-RateLimit-Remaining' => (string) $rateLimit['remaining'],
-                'X-RateLimit-Reset'     => (string) $rateLimit['reset'],
-            ];
+            $rlHeaders   = array_merge(
+                [
+                    'X-RateLimit-Limit'     => (string) $rateLimit['limit'],
+                    'X-RateLimit-Remaining' => (string) $rateLimit['remaining'],
+                    'X-RateLimit-Reset'     => (string) $rateLimit['reset'],
+                ],
+                self::securityHeaders()
+            );
 
             if (!$rateLimit['allowed']) {
                 $logger->warning(sprintf('Rate limit exceeded for IP %s on /api/retrieve', $ip));

--- a/server/tests/Unit/SecurityHeadersTest.php
+++ b/server/tests/Unit/SecurityHeadersTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swordfish\Server\Tests;
+
+use Amp\Http\Server\Driver\Client;
+use Amp\Http\Server\Request;
+use Amp\Http\Server\RequestHandler\CallableRequestHandler;
+use Amp\Http\Server\Response;
+use Amp\Http\Server\Router;
+use Amp\Http\Status;
+use League\Uri\Http;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Predis\Client as RedisClient;
+use Swordfish\Server\ServerRoutes;
+
+class SecurityHeadersTest extends TestCase
+{
+    private const EXPECTED_HEADERS = [
+        'content-security-policy'   => "default-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'none'",
+        'x-content-type-options'    => 'nosniff',
+        'x-frame-options'           => 'DENY',
+        'referrer-policy'           => 'strict-origin-when-cross-origin',
+        'strict-transport-security' => 'max-age=31536000; includeSubDomains',
+    ];
+
+    private function assertHasSecurityHeaders(Response $response): void
+    {
+        foreach (self::EXPECTED_HEADERS as $name => $value) {
+            $this->assertSame($value, $response->getHeader($name), "Missing or incorrect header: {$name}");
+        }
+    }
+
+    private function makeGetRequest(string $path = '/'): Request
+    {
+        $client = $this->createMock(Client::class);
+        return new Request($client, 'GET', Http::new('http://localhost' . $path));
+    }
+
+    private function makePostRequest(string $path, string $body = ''): Request
+    {
+        $client  = $this->createMock(Client::class);
+        $request = new Request($client, 'POST', Http::new('http://localhost' . $path));
+        $request->setBody($body);
+        return $request;
+    }
+
+    private function makeRedisMock(array $methods = []): RedisClient
+    {
+        return $this->getMockBuilder(RedisClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods($methods)
+            ->getMock();
+    }
+
+    public function testMainContentIncludesSecurityHeaders(): void
+    {
+        $handler  = ServerRoutes::mainContent(new Logger('test'));
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeGetRequest('/')));
+
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testSecretRetrievalIncludesSecurityHeaders(): void
+    {
+        $client  = $this->createMock(Client::class);
+        $request = new Request($client, 'GET', Http::new('http://localhost/secret'));
+        $request->setAttribute(Router::class, []);
+
+        $handler  = ServerRoutes::secretRetrieval(new Logger('test'));
+        $response = \Amp\Promise\wait($handler->handleRequest($request));
+
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testSpaFallbackIncludesSecurityHeadersOnIndexFallback(): void
+    {
+        $documentRoot = new CallableRequestHandler(function(): Response {
+            return new Response(Status::NOT_FOUND, [], '');
+        });
+
+        $handler  = ServerRoutes::spaFallback(new Logger('test'), $documentRoot);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeGetRequest('/about')));
+
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testSpaFallbackIncludesSecurityHeadersOnPassThrough(): void
+    {
+        $documentRoot = new CallableRequestHandler(function(): Response {
+            return new Response(Status::OK, ['content-type' => 'application/javascript'], 'console.log("app");');
+        });
+
+        $handler  = ServerRoutes::spaFallback(new Logger('test'), $documentRoot);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeGetRequest('/assets/index.js')));
+
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testRedirectCreateIncludesSecurityHeaders(): void
+    {
+        $handler  = ServerRoutes::redirectCreate(new Logger('test'));
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makePostRequest('/create')));
+
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testRedirectRetrieveIncludesSecurityHeaders(): void
+    {
+        $handler  = ServerRoutes::redirectRetrieve(new Logger('test'));
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makePostRequest('/retrieve')));
+
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testHealthCheckIncludesSecurityHeadersOnSuccess(): void
+    {
+        $redis = $this->makeRedisMock(['ping']);
+        $redis->expects($this->once())->method('ping');
+
+        $handler  = ServerRoutes::healthCheck(new Logger('test'), $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeGetRequest('/health')));
+
+        $this->assertSame(Status::OK, $response->getStatus());
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testHealthCheckIncludesSecurityHeadersOnFailure(): void
+    {
+        $redis = $this->makeRedisMock(['ping']);
+        $redis->method('ping')->willThrowException(new \RuntimeException('Connection refused'));
+
+        $handler  = ServerRoutes::healthCheck(new Logger('test'), $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeGetRequest('/health')));
+
+        $this->assertSame(Status::SERVICE_UNAVAILABLE, $response->getStatus());
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testCreateSecretIncludesSecurityHeadersOnSuccess(): void
+    {
+        $redis = $this->makeRedisMock(['setex']);
+        $redis->expects($this->exactly(3))->method('setex');
+
+        $salt      = bin2hex(str_repeat('a', 16));
+        $verifier  = bin2hex(str_repeat('b', 32));
+        $secret    = bin2hex('mysecret');
+        $payload   = json_encode(['encrypted_secret' => "{$salt}\${$verifier}\${$secret}", 'ttl' => 3600, 'max_views' => 0]);
+
+        $handler  = ServerRoutes::createSecret(new Logger('test'), $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makePostRequest('/api/create', $payload)));
+
+        $this->assertSame(Status::CREATED, $response->getStatus());
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testCreateSecretIncludesSecurityHeadersOnBadRequest(): void
+    {
+        $redis   = $this->makeRedisMock([]);
+        $handler = ServerRoutes::createSecret(new Logger('test'), $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makePostRequest('/api/create', 'not-json')));
+
+        $this->assertSame(Status::BAD_REQUEST, $response->getStatus());
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testCreateSecretIncludesSecurityHeadersOnPayloadTooLarge(): void
+    {
+        $redis   = $this->makeRedisMock([]);
+        $handler = ServerRoutes::createSecret(new Logger('test'), $redis);
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makePostRequest('/api/create', str_repeat('x', 101 * 1000))));
+
+        $this->assertSame(Status::PAYLOAD_TOO_LARGE, $response->getStatus());
+        $this->assertHasSecurityHeaders($response);
+    }
+
+    public function testCspAllowsOnlySameOriginScriptsAndStyles(): void
+    {
+        $handler  = ServerRoutes::mainContent(new Logger('test'));
+        $response = \Amp\Promise\wait($handler->handleRequest($this->makeGetRequest('/')));
+
+        $csp = $response->getHeader('content-security-policy');
+        $this->assertNotNull($csp);
+        $this->assertStringContainsString("default-src 'self'", $csp);
+        $this->assertStringNotContainsString("'unsafe-inline'", $csp);
+        $this->assertStringNotContainsString("'unsafe-eval'", $csp);
+    }
+}


### PR DESCRIPTION
## Summary

Closes / references: [DIS-912](https://linear.app/displace-tech/issue/DIS-912/add-security-response-headers-to-php-server)

Adds the following security headers to **all** HTTP responses from the PHP server:

| Header | Value |
|---|---|
| `Content-Security-Policy` | `default-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'none'` |
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `DENY` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |

## Implementation

- Added a private `securityHeaders(): array` helper to `ServerRoutes` that returns the canonical set of security headers.
- Applied `array_merge([...], self::securityHeaders())` to every `new Response(...)` call across all route handlers.
- For the `spaFallback` handler, headers are injected into both the SPA index fallback response and pass-through static asset responses.
- For `retrieveSecretJson`, security headers are merged into `$rlHeaders` so they are present on all rate-limit and error responses too.

## CSP and SPA compatibility

The Vite build emits only external hashed asset files (`/assets/index-*.js`, `/assets/index-*.css`) with no inline scripts or styles, so `default-src 'self'` is fully compatible with the SPA — no `'unsafe-inline'` or `'unsafe-eval'` directives are needed.

## Tests

Added `server/tests/Unit/SecurityHeadersTest.php` with 12 test cases covering:
- Security headers present on every handler (main page, secret retrieval, SPA fallback, redirects, health check, create secret)
- Headers present on both success and error responses
- CSP does not include `'unsafe-inline'` or `'unsafe-eval'`

All 102 unit tests pass.