### PR TITLE
Fix /metrics and /about 500 error: register explicit SPA routes

### DIFF
--- a/server/server.php
+++ b/server/server.php
@@ -58,6 +58,8 @@ Amp\Loop::run(function () {
     $router->addRoute('GET', '/', ServerRoutes::mainContent($logger));
     $router->addRoute('GET', '/secret', ServerRoutes::secretRetrieval($logger));
     $router->addRoute('GET', '/secret/{secretId}', ServerRoutes::secretRetrieval($logger));
+    $router->addRoute('GET', '/about', ServerRoutes::mainContent($logger));
+    $router->addRoute('GET', '/metrics', ServerRoutes::mainContent($logger));
     $router->addRoute('GET', '/health', ServerRoutes::healthCheck($logger, $redisClient));
 
     /***********************************************************/


### PR DESCRIPTION
## Summary

- `/metrics` (and `/about`) were returning 500 errors because they relied on the SPA fallback handler, which calls `DocumentRoot::handleRequest()`. Since `DocumentRoot::onStart()` is never invoked (it's not registered as a `ServerObserver`), its internal state is null and it crashes.
- Fix: register `/metrics` and `/about` as explicit routes using `mainContent()`, which directly serves `index.html` — the same pattern used for `/` and `/secret`.

## Test plan

- [ ] `GET /metrics` returns 200 and renders the dashboard
- [ ] `GET /about` returns 200 and renders the How It Works page
- [ ] CI passes


Made with [Cursor](https://cursor.com)