### PR TITLE
Fix cleanup job deleting latest container image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -127,7 +127,7 @@ jobs:
         with:
           context: .
           file: server/Dockerfile
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
- Restricts container image pushes to GHCR to main branch only (login + push conditions)
- Branch pushes (Dependabot, feature branches) still build for CI validation but no longer push images

## Root cause
The build workflow pushed images on **any** branch push, but only tagged `latest` on main. Dependabot branch pushes created SHA-only versions that were newer (by creation date) than the `latest`-tagged main version. When the weekly cleanup ran with `min-versions-to-keep: 5`, it deleted `latest` because it wasn't among the 5 newest versions — causing `ImagePullBackOff` when the pod was rescheduled.

## Test plan
- [ ] Verify CI still runs tests on PR branches (test + js-test jobs unaffected)
- [ ] Verify build job runs but does not push on PR branches
- [ ] Verify merges to main still push images with SHA + `latest` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)