### PR TITLE
Add release image tagging, protect versioned images from cleanup

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -9,14 +9,52 @@ jobs:
   delete-old-versions:
     runs-on: ubuntu-latest
     permissions:
-      packages: write # Grant the workflow necessary permissions to delete packages
+      packages: write
       contents: read
     steps:
-      - name: Delete old package versions
-        uses: actions/delete-package-versions@v5
-        with:
-          owner: DisplaceTech
-          package-name: 'swordfish/server'
-          package-type: 'container'
-          min-versions-to-keep: 5
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete old untagged package versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKAGE="swordfish%2Fserver"
+          ORG="DisplaceTech"
+          MIN_KEEP=5
+
+          # Get all versions: id, tags, created_at (newest first from API)
+          VERSIONS=$(gh api \
+            --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/orgs/$ORG/packages/container/$PACKAGE/versions" \
+            --jq '.[] | "\(.id)\t\(.metadata.container.tags | join(","))"')
+
+          DELETABLE=()
+          while IFS=$'\t' read -r ID TAGS; do
+            [ -z "$ID" ] && continue
+
+            # Protect versions tagged with "latest" or a version tag (v*)
+            if echo ",$TAGS," | grep -qE ',latest,|,v[0-9]'; then
+              echo "Keeping version $ID (tags: ${TAGS:-<none>})"
+              continue
+            fi
+
+            DELETABLE+=("$ID")
+          done <<< "$VERSIONS"
+
+          TOTAL=${#DELETABLE[@]}
+          echo "Found $TOTAL deletable versions (SHA-only or untagged)"
+
+          if [ "$TOTAL" -le "$MIN_KEEP" ]; then
+            echo "At or below minimum ($MIN_KEEP), nothing to delete"
+            exit 0
+          fi
+
+          # API returns newest first, so keep the first MIN_KEEP and delete the rest
+          TO_DELETE=("${DELETABLE[@]:$MIN_KEEP}")
+          echo "Deleting ${#TO_DELETE[@]} old versions (keeping newest $MIN_KEEP)"
+
+          for ID in "${TO_DELETE[@]}"; do
+            echo "Deleting version $ID"
+            gh api --method DELETE \
+              -H "Accept: application/vnd.github+json" \
+              "/orgs/$ORG/packages/container/$PACKAGE/versions/$ID" || true
+          done

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,48 @@
+name: Tag Release Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to apply (e.g. v1.0.0)'
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/server
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Determine version tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull latest image and push with version tag
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          VERSION="${{ steps.version.outputs.tag }}"
+          docker pull "${IMAGE}:latest"
+          docker tag "${IMAGE}:latest" "${IMAGE}:${VERSION}"
+          docker push "${IMAGE}:${VERSION}"
+          echo "Tagged ${IMAGE}:latest as ${IMAGE}:${VERSION}"


### PR DESCRIPTION
## Summary
- Adds `release-tag.yml` workflow: automatically tags the `latest` container image with the git tag version when a `v*` tag is pushed. Also supports `workflow_dispatch` for retroactive tagging (e.g. to tag the current image as `v1.0.0`).
- Rewrites `cleanup.yml` to use the GitHub API directly so it can inspect container tags. Images tagged with `latest` or `v*` are now **protected from deletion** — only SHA-only and untagged versions are cleaned up.

## Context
The previous cleanup job used `actions/delete-package-versions` which has no concept of protected tags — it just deletes the oldest N versions. Combined with the branch-push issue fixed in #108, this deleted the `latest` image and took down the site. This rewrite ensures version-tagged releases are never garbage collected.

## Test plan
- [ ] Merge, then trigger `release-tag` via workflow_dispatch with `v1.0.0` to tag the current image
- [ ] Verify `cleanup` workflow_dispatch runs without deleting protected versions
- [ ] Future `v*` tag pushes should auto-tag the container image

🤖 Generated with [Claude Code](https://claude.com/claude-code)