### PR TITLE
Fix release-tag workflow: lowercase image name for Docker

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Pull latest image and push with version tag
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          IMAGE=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
           VERSION="${{ steps.version.outputs.tag }}"
           docker pull "${IMAGE}:latest"
           docker tag "${IMAGE}:latest" "${IMAGE}:${VERSION}"


### PR DESCRIPTION
## Summary
- Lowercases the image reference in the release-tag workflow via `tr`
- `github.repository` returns `DisplaceTech/swordfish` with original casing, but Docker requires all-lowercase references
- The `docker/metadata-action` in build.yml handles this automatically, but raw `docker pull/push` commands do not

## Test plan
- [ ] Re-run release-tag workflow_dispatch with `v1.0.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)